### PR TITLE
feat: host frontend on GitHub Pages for free

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy Frontend to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,6 +101,32 @@ FormData { file: File }
 }
 ```
 
+## Free Hosting (GitHub Pages)
+
+The `frontend/` directory is deployed to GitHub Pages automatically on every
+push to `main` via `.github/workflows/pages.yml`.
+
+### One-time setup
+
+1. Push this branch and merge it to `main`.
+2. In the GitHub repo: **Settings → Pages → Build and deployment → Source**:
+   select **GitHub Actions**.
+3. The `Deploy Frontend to GitHub Pages` workflow will publish the site to
+   `https://<user>.github.io/<repo>/`.
+
+### Backend
+
+GitHub Pages serves static files only. The frontend's `/api/*` calls require a
+separately hosted backend. Free options for the FastAPI backend include:
+
+- [Render](https://render.com) (free web service tier)
+- [Fly.io](https://fly.io) (free allowance)
+- [Railway](https://railway.app) (trial credits)
+- [Hugging Face Spaces](https://huggingface.co/spaces) with a Docker SDK
+
+Point `API_BASE` in `frontend/js/api.js` at the deployed backend URL and ensure
+CORS is enabled there.
+
 ## Browser Support
 
 Modern browsers with ES6+ module support:


### PR DESCRIPTION
Add a workflow that publishes the frontend/ directory to GitHub Pages on
every push to main. Document the one-time Pages setup and free backend
hosting options in the frontend README.