### PR TITLE
chore: fix pre-commit/quality CI failures on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,8 @@ repos:
           - typer>=0.19.0
           - rich>=13.9.0
           - pydantic-settings>=2.6.0
+          - fastapi>=0.115.0
+          - httpx>=0.27.0
           - types-requests
         exclude: ^tests/
         args: [--strict]
@@ -57,6 +59,8 @@ repos:
     rev: 6.3.0
     hooks:
       - id: pydocstyle
+        additional_dependencies:
+          - tomli
         exclude: ^tests/
         args: [--convention=google]
 

--- a/API_116117.md
+++ b/API_116117.md
@@ -114,15 +114,15 @@ from datetime import datetime
 def generate_req_val() -> str:
     now = datetime.now()
     timestamp_ms = int(time.time() * 1000)
-    
+
     year = str(now.year)
     month = str(now.month).zfill(2)
     day = str(now.day).zfill(2)
     hour = str(now.hour).zfill(2)
-    
+
     components = f"{year}{month}{day}{hour}{timestamp_ms}"
     token = hashlib.sha256(components.encode()).hexdigest()[:32]
-    
+
     return token
 ```
 
@@ -154,7 +154,7 @@ params = SearchParams(
 # Search for therapists
 with Arztsuche116117Client() as client:
     therapists = client.search_therapists(params)
-    
+
     for therapist in therapists:
         print(f"{therapist.name} - {therapist.phone}")
 ```

--- a/test_api_116117.py
+++ b/test_api_116117.py
@@ -7,8 +7,8 @@ This script demonstrates how to:
 3. Handle the API authentication and dynamic headers
 """
 
-import sys
 from pathlib import Path
+import sys
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent))
@@ -23,7 +23,7 @@ except ImportError:
     sys.exit(1)
 
 
-def test_location_search():
+def test_location_search() -> None:
     """Test location search functionality."""
     print("\n" + "=" * 60)
     print("Testing Location Search")
@@ -35,17 +35,21 @@ def test_location_search():
         results = client.search_location("Berlin")
         print(f"Found {len(results)} results")
         for i, loc in enumerate(results[:3], 1):
-            print(f"{i}. {loc.get('name', 'N/A')} - Lat: {loc.get('lat')}, Lon: {loc.get('lon')}")
+            print(
+                f"{i}. {loc.get('name', 'N/A')} - Lat: {loc.get('lat')}, Lon: {loc.get('lon')}"
+            )
 
         # Test with postal code
         print("\nSearching for: 10115")
         results = client.search_location("10115")
         print(f"Found {len(results)} results")
         for i, loc in enumerate(results[:3], 1):
-            print(f"{i}. {loc.get('name', 'N/A')} - Lat: {loc.get('lat')}, Lon: {loc.get('lon')}")
+            print(
+                f"{i}. {loc.get('name', 'N/A')} - Lat: {loc.get('lat')}, Lon: {loc.get('lon')}"
+            )
 
 
-def test_therapist_search():
+def test_therapist_search() -> None:
     """Test therapist search functionality."""
     print("\n" + "=" * 60)
     print("Testing Therapist Search")
@@ -58,7 +62,7 @@ def test_therapist_search():
         max_results=5,
     )
 
-    print(f"\nSearch parameters:")
+    print("\nSearch parameters:")
     print(f"  Specialty: {params.specialty}")
     print(f"  Location: {params.location}")
     print(f"  Radius: {params.radius} km")
@@ -86,10 +90,11 @@ def test_therapist_search():
         except Exception as e:
             print(f"\nError during search: {e}")
             import traceback
+
             traceback.print_exc()
 
 
-def test_authentication():
+def test_authentication() -> None:
     """Test API authentication."""
     print("\n" + "=" * 60)
     print("Testing API Authentication")
@@ -100,11 +105,11 @@ def test_authentication():
     print(f"Password (decoded): {client.password[:8]}...")
     print(f"Base URL: {client.BASE_URL}")
     print(f"API Path: {client.API_PATH}")
-    
+
     # Test req-val generation
     req_val = client._generate_req_val()
     print(f"Generated req-val token: {req_val}")
-    
+
     client.close()
 
 
@@ -129,5 +134,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n\nFatal error: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)

--- a/therapist_finder/api/routes/emails.py
+++ b/therapist_finder/api/routes/emails.py
@@ -3,8 +3,8 @@
 from fastapi import APIRouter, HTTPException
 
 from ...config import Settings
-from ...models import EmailDraft, TherapistData, UserInfo
 from ...email.generator import EmailGenerator
+from ...models import TherapistData, UserInfo
 from ...utils.applescript_generator import create_applescript_content
 from ..schemas import (
     EmailDraftResponse,
@@ -46,10 +46,10 @@ def _generate_csv(therapists: list[TherapistResponse]) -> str:
 
     for t in therapists:
         row = [
-            f'"{(t.name or "").replace(chr(34), chr(34)+chr(34))}"',
-            f'"{(t.email or "").replace(chr(34), chr(34)+chr(34))}"',
-            f'"{(t.phone or "").replace(chr(34), chr(34)+chr(34))}"',
-            f'"{(t.address or "").replace(chr(34), chr(34)+chr(34))}"',
+            f'"{(t.name or "").replace(chr(34), chr(34) + chr(34))}"',
+            f'"{(t.email or "").replace(chr(34), chr(34) + chr(34))}"',
+            f'"{(t.phone or "").replace(chr(34), chr(34) + chr(34))}"',
+            f'"{(t.address or "").replace(chr(34), chr(34) + chr(34))}"',
         ]
         rows.append(",".join(row))
 

--- a/therapist_finder/cli.py
+++ b/therapist_finder/cli.py
@@ -156,7 +156,9 @@ def show_statistics(
 
 @app.command()
 def search_116117(
-    specialty: str = typer.Option("Psychotherapeut", "--specialty", "-s", help="Therapist specialty"),
+    specialty: str = typer.Option(
+        "Psychotherapeut", "--specialty", "-s", help="Therapist specialty"
+    ),
     location: str = typer.Option(..., "--location", "-l", help="City or postal code"),
     radius: int = typer.Option(25, "--radius", "-r", help="Search radius in km"),
     max_results: int = typer.Option(50, "--max", "-m", help="Maximum results"),
@@ -165,11 +167,15 @@ def search_116117(
     """Search for therapists using arztsuche.116117.de API."""
     try:
         from .parsers.arztsuche_api import Arztsuche116117Client, SearchParams
-    except ImportError:
-        rprint("[red]Error: httpx is required for API access. Install with: poetry add httpx[/red]")
-        raise typer.Exit(1)
+    except ImportError as err:
+        rprint(
+            "[red]Error: httpx is required for API access. Install with: poetry add httpx[/red]"
+        )
+        raise typer.Exit(1) from err
 
-    console.print(f"\n[bold blue]Searching for {specialty} in {location}...[/bold blue]")
+    console.print(
+        f"\n[bold blue]Searching for {specialty} in {location}...[/bold blue]"
+    )
 
     # Create search parameters
     params = SearchParams(
@@ -185,7 +191,7 @@ def search_116117(
             therapists = client.search_therapists(params)
     except Exception as e:
         rprint(f"[red]Error: API request failed: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if not therapists:
         rprint("[yellow]No therapists found[/yellow]")
@@ -209,32 +215,26 @@ def search_116117(
     # Save results if output directory specified
     if output_dir:
         output_dir.mkdir(parents=True, exist_ok=True)
-        
-        # Convert to TherapistData format
-        from .models import Therapist
-        
-        therapist_list = []
-        for t in therapists:
-            therapist_list.append(
-                Therapist(
-                    name=t.name,
-                    street=t.street or "",
-                    city=t.city or "",
-                    postal_code=t.postal_code or "",
-                    phone=t.phone or "",
-                    email=t.email or "",
-                )
+
+        therapist_list = [
+            TherapistData(
+                name=t.name,
+                address=f"{t.street or ''}, {t.postal_code or ''} {t.city or ''}".strip(
+                    ", "
+                ),
+                telefon=t.phone or None,
+                email=t.email or None,
             )
-        
-        data = TherapistData(therapists=therapist_list)
-        
+            for t in therapists
+        ]
+
         json_path = output_dir / "therapists_116117.json"
         md_path = output_dir / "therapists_116117.md"
-        
-        save_json(data, json_path)
-        save_markdown(data, md_path)
-        
-        console.print(f"\n[green]✓ Results saved to:[/green]")
+
+        save_json([td.model_dump() for td in therapist_list], json_path)
+        save_markdown(therapist_list, md_path)
+
+        console.print("\n[green]✓ Results saved to:[/green]")
         console.print(f"  JSON: {json_path}")
         console.print(f"  Markdown: {md_path}")
 

--- a/therapist_finder/parsers/arztsuche_api.py
+++ b/therapist_finder/parsers/arztsuche_api.py
@@ -1,13 +1,14 @@
-"""API client for arztsuche.116117.de
+"""API client for arztsuche.116117.de.
 
 This module provides a client for searching therapists using the
 official German medical directory API (Arztsuche 116117).
 """
 
+from datetime import datetime
 import hashlib
 import time
-from datetime import datetime
-from typing import Any
+from types import TracebackType
+from typing import Any, cast
 
 import httpx
 from pydantic import BaseModel, Field
@@ -16,7 +17,9 @@ from pydantic import BaseModel, Field
 class SearchParams(BaseModel):
     """Parameters for therapist search."""
 
-    specialty: str = Field(..., description="Therapist specialty (e.g., 'Psychotherapeut')")
+    specialty: str = Field(
+        ..., description="Therapist specialty (e.g., 'Psychotherapeut')"
+    )
     location: str = Field(..., description="City or postal code")
     max_results: int = Field(50, description="Maximum number of results", ge=1, le=50)
     radius: int = Field(25, description="Search radius in km", ge=1, le=100)
@@ -37,7 +40,7 @@ class Therapist116117(BaseModel):
 
 class Arztsuche116117Client:
     """Client for interacting with arztsuche.116117.de API.
-    
+
     The API requires HTTP Basic Authentication with credentials that are
     embedded in the website's JavaScript. It also requires a dynamic
     request validation header that includes timestamp-based tokens.
@@ -48,9 +51,9 @@ class Arztsuche116117Client:
 
     # API credentials (decoded from JS)
     USERNAME = "bdps"
-    PASSWORD = "fkr493mvg_f"
+    PASSWORD = "fkr493mvg_f"  # nosec B105 - public API credential from 116117 JS
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the API client."""
         self.username = self.USERNAME
         self.password = self.PASSWORD
@@ -67,38 +70,38 @@ class Arztsuche116117Client:
 
     def _generate_req_val(self) -> str:
         """Generate the req-val header for API requests.
-        
+
         The req-val header is a dynamic token that includes timestamp
         components to prevent replay attacks.
-        
+
         Returns:
             The req-val token string.
         """
         now = datetime.now()
         timestamp_ms = int(time.time() * 1000)
-        
+
         # Components used in the hash calculation
         year = str(now.year)
         month = str(now.month).zfill(2)
         day = str(now.day).zfill(2)
         hour = str(now.hour).zfill(2)
-        
+
         # The website uses a specific formula to generate this token
         # This is a simplified version - the actual implementation may vary
         components = f"{year}{month}{day}{hour}{timestamp_ms}"
         token = hashlib.sha256(components.encode()).hexdigest()[:32]
-        
+
         return token
 
     def search_location(self, query: str) -> list[dict[str, Any]]:
         """Search for location suggestions.
-        
+
         Args:
             query: City name or postal code to search for.
-            
+
         Returns:
             List of location suggestions with coordinates.
-            
+
         Raises:
             httpx.HTTPError: If the API request fails.
         """
@@ -108,17 +111,17 @@ class Arztsuche116117Client:
             headers={"req-val": self._generate_req_val()},
         )
         response.raise_for_status()
-        return response.json()
+        return cast(list[dict[str, Any]], response.json())
 
     def search_therapists(self, params: SearchParams) -> list[Therapist116117]:
         """Search for therapists using the 116117 API.
-        
+
         Args:
             params: Search parameters including specialty and location.
-            
+
         Returns:
             List of therapists matching the search criteria.
-            
+
         Raises:
             httpx.HTTPError: If the API request fails.
         """
@@ -126,9 +129,9 @@ class Arztsuche116117Client:
         locations = self.search_location(params.location)
         if not locations:
             return []
-        
+
         location_data = locations[0]  # Use first result
-        
+
         # Prepare search request
         search_data = {
             "specialty": params.specialty,
@@ -137,18 +140,18 @@ class Arztsuche116117Client:
             "radius": params.radius,
             "limit": params.max_results,
         }
-        
+
         response = self.client.post(
             f"{self.API_PATH}/data",
             json=search_data,
             headers={"req-val": self._generate_req_val()},
         )
         response.raise_for_status()
-        
+
         # Parse results
         results = response.json()
         therapists = []
-        
+
         for item in results.get("results", []):
             therapist = Therapist116117(
                 name=item.get("name", ""),
@@ -161,17 +164,22 @@ class Arztsuche116117Client:
                 distance=item.get("distance"),
             )
             therapists.append(therapist)
-        
+
         return therapists
 
-    def close(self):
+    def close(self) -> None:
         """Close the HTTP client."""
         self.client.close()
 
-    def __enter__(self):
+    def __enter__(self) -> "Arztsuche116117Client":
         """Context manager entry."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Context manager exit."""
         self.close()


### PR DESCRIPTION
## Summary
Clear the pre-existing lint debt that was making the `pre-commit` and `quality` CI jobs red on every PR. `poetry run pre-commit run --all-files` is now green locally.

## What changed
- **Auto-fixes**: `black`, `ruff --fix`, `ruff-format`, and trailing-whitespace cleanups across `API_116117.md`, `test_api_116117.py`, `therapist_finder/cli.py`, `therapist_finder/parsers/arztsuche_api.py`, `therapist_finder/api/routes/emails.py`.
- **`cli.py`**: `raise typer.Exit(1) from err/e` to satisfy ruff `B904`. Also fix broken references to a non-existent `models.Therapist` and to `TherapistData`'s field list — build a real `list[TherapistData]` and pass it to `save_json` / `save_markdown` with the shapes they expect.
- **`parsers/arztsuche_api.py`**: pydocstyle `D415` period on the module docstring; `# nosec B105` on the credential literal (it's the public 116117 JS client credential, documented in `API_116117.md`); return/parameter annotations on `__init__`, `close`, `__enter__`, `__exit__`; cast `search_location` JSON to a concrete type to silence mypy `no-any-return`.
- **`test_api_116117.py`**: `-> None` on the three `test_*` functions.
- **`.pre-commit-config.yaml`**:
  - add `fastapi` and `httpx` to the mypy hook so `--strict` can resolve the imports and decorator types.
  - add `tomli` to the pydocstyle hook so its `pyproject.toml` config (including `match = "(?!test_).*\.py"`) is actually honored.

## Test plan
- [ ] `pre-commit` workflow passes on this PR.
- [ ] `quality` workflow passes on this PR.
- [ ] `test (3.10/3.11/3.12)` workflows pass.

https://claude.ai/code/session_01Az8pW5VvSpdMfiZ4mgCom3