### PR TITLE
Point GitHub Pages frontend at the Render backend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <script>window.API_BASE = 'https://therapist-finder-api.onrender.com/api';</script>
 </head>
 <body>
     <div class="app">


### PR DESCRIPTION
## Summary
Set `window.API_BASE` in `frontend/index.html` to the live Render URL so the Pages-hosted static frontend calls `https://therapist-finder-api.onrender.com/api/*` instead of a non-existent same-origin `/api`.

## Prerequisites on Render
- [ ] Service `therapist-finder-api` is live and `/api/health` returns 200.
- [ ] `CORS_ORIGINS=https://anneoneone.github.io` is set on the service so the Pages origin is allowed.

## Test plan
- [ ] Merge → Pages workflow redeploys → https://anneoneone.github.io/therapist-finder/ loads.
- [ ] DevTools Network: uploading a PDF hits `https://therapist-finder-api.onrender.com/api/therapists/parse` and succeeds with no CORS errors.
- [ ] Generating emails hits `/api/emails/generate` and returns drafts.

https://claude.ai/code/session_01Az8pW5VvSpdMfiZ4mgCom3