### PR TITLE
feat: cross-platform mailto: email draft queue

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,10 @@ A modern, simple frontend for Therapist Finder built with vanilla JavaScript and
 - **File Upload**: Drag & drop or click to upload PDF/text files
 - **User Info Form**: Collect user information for email personalization
 - **Results Table**: Display parsed therapists with status indicators
-- **Downloads**: Export CSV table and AppleScript file
+- **CSV Export**: Download the therapist table as CSV
+- **Email Draft Queue**: Sequential `mailto:` flow that opens one pre-filled draft
+  at a time in the user's default mail client (works on Windows, macOS, Linux).
+  Contacted addresses are remembered in `localStorage` and skipped on reruns.
 
 ## Structure
 
@@ -48,7 +51,7 @@ The frontend expects these API endpoints:
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/api/therapists/parse` | Upload file, returns parsed therapists |
-| `POST` | `/api/emails/generate` | Generate emails, returns drafts + AppleScript |
+| `POST` | `/api/emails/generate` | Generate emails, returns drafts + CSV |
 | `GET` | `/api/health` | Health check |
 
 ### Request: Parse File
@@ -94,10 +97,11 @@ FormData { file: File }
     {
       "to": "m.schmidt@example.com",
       "subject": "Anfrage Psychotherapie",
-      "body": "..."
+      "body": "...",
+      "therapist_name": "Dr. Maria Schmidt"
     }
   ],
-  "applescript": "tell application \"Mail\"..."
+  "table_csv": "Name,Email,Phone,Address\n..."
 }
 ```
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -495,6 +495,141 @@ body {
 }
 
 /* ========================================
+   Email Draft Queue
+   ======================================== */
+
+.queue-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-lg);
+    z-index: 100;
+    animation: fadeIn var(--transition-base) ease-out;
+}
+
+.queue-modal {
+    background: var(--color-bg-white);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-lg);
+    width: 100%;
+    max-width: 640px;
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.queue-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-lg) var(--space-xl);
+    border-bottom: 1px solid var(--color-border);
+}
+
+.queue-header h3 {
+    flex: 1;
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+}
+
+.queue-body {
+    padding: var(--space-lg) var(--space-xl);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+}
+
+.queue-therapist {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+}
+
+.queue-therapist-name {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.queue-therapist-email {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-muted);
+    word-break: break-all;
+}
+
+.queue-preview {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.queue-preview-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    font-size: var(--font-size-sm);
+}
+
+.queue-preview-label {
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.queue-preview-body pre {
+    font-family: var(--font-family);
+    font-size: var(--font-size-sm);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 220px;
+    overflow-y: auto;
+    background: var(--color-bg-white);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-sm);
+    color: var(--color-text);
+}
+
+.queue-warning {
+    background: var(--color-warning-light);
+    color: var(--color-warning);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    font-size: var(--font-size-sm);
+    line-height: 1.5;
+}
+
+.queue-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: var(--space-sm);
+    padding: var(--space-lg) var(--space-xl);
+    border-top: 1px solid var(--color-border);
+    background: var(--color-bg);
+}
+
+@media (max-width: 600px) {
+    .queue-actions {
+        justify-content: stretch;
+    }
+    .queue-actions .btn {
+        flex: 1 1 45%;
+    }
+}
+
+/* ========================================
    Utilities
    ======================================== */
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -104,8 +104,8 @@
                         <button class="btn btn-secondary" id="download-table">
                             📊 Download Table
                         </button>
-                        <button class="btn btn-primary" id="download-applescript">
-                            🍎 Download AppleScript
+                        <button class="btn btn-primary" id="open-queue">
+                            📬 Open Email Drafts
                         </button>
                     </div>
                 </div>
@@ -129,6 +129,43 @@
                 </div>
             </section>
         </main>
+
+        <!-- Email draft queue modal -->
+        <div class="queue-overlay" id="queue-overlay" hidden>
+            <div class="queue-modal" role="dialog" aria-modal="true" aria-labelledby="queue-title">
+                <header class="queue-header">
+                    <h3 id="queue-title">
+                        Contact therapist
+                        <span id="queue-position">1</span> of <span id="queue-total">1</span>
+                    </h3>
+                    <button class="btn-icon" id="queue-close" title="Close" aria-label="Close">✕</button>
+                </header>
+                <div class="queue-body">
+                    <div class="queue-therapist" id="queue-therapist"></div>
+                    <div class="queue-preview">
+                        <div class="queue-preview-row">
+                            <span class="queue-preview-label">Subject</span>
+                            <span id="queue-subject"></span>
+                        </div>
+                        <div class="queue-preview-row queue-preview-body">
+                            <span class="queue-preview-label">Body</span>
+                            <pre id="queue-body-preview"></pre>
+                        </div>
+                    </div>
+                    <div class="queue-warning" id="queue-truncation-warning" hidden>
+                        ⚠️ This email is long and may be cut off when your mail app opens it.
+                        Use <strong>Copy body</strong> to paste the full text into the compose window.
+                    </div>
+                    <div class="status" id="queue-status" hidden></div>
+                </div>
+                <footer class="queue-actions">
+                    <button class="btn btn-secondary" id="queue-copy-body">📋 Copy body</button>
+                    <button class="btn btn-secondary" id="queue-skip">Skip</button>
+                    <button class="btn btn-primary" id="queue-open">📧 Open in mail app</button>
+                    <button class="btn btn-primary" id="queue-next" disabled>Next →</button>
+                </footer>
+            </div>
+        </div>
 
         <footer class="footer">
             <div class="container">

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -14,7 +14,12 @@ const state = {
     therapists: [],
     userInfo: {},
     results: null,
+    queue: { items: [], index: 0 },
 };
+
+const CONTACTED_STORAGE_KEY = 'therapist-finder:contacted-emails';
+const MAILTO_MAX_LENGTH = 1900;
+const TRUNCATION_MARKER = '\n\n[… truncated — use "Copy body" to paste full text]';
 
 // ============================================
 // DOM Elements
@@ -40,7 +45,22 @@ const elements = {
     resultsSummary: document.getElementById('results-summary'),
     therapistsTbody: document.getElementById('therapists-tbody'),
     downloadTable: document.getElementById('download-table'),
-    downloadApplescript: document.getElementById('download-applescript'),
+    openQueue: document.getElementById('open-queue'),
+
+    // Queue modal
+    queueOverlay: document.getElementById('queue-overlay'),
+    queueClose: document.getElementById('queue-close'),
+    queuePosition: document.getElementById('queue-position'),
+    queueTotal: document.getElementById('queue-total'),
+    queueTherapist: document.getElementById('queue-therapist'),
+    queueSubject: document.getElementById('queue-subject'),
+    queueBodyPreview: document.getElementById('queue-body-preview'),
+    queueTruncationWarning: document.getElementById('queue-truncation-warning'),
+    queueStatus: document.getElementById('queue-status'),
+    queueCopyBody: document.getElementById('queue-copy-body'),
+    queueSkip: document.getElementById('queue-skip'),
+    queueOpen: document.getElementById('queue-open'),
+    queueNext: document.getElementById('queue-next'),
 };
 
 // ============================================
@@ -259,7 +279,7 @@ async function handleGenerateEmails(event) {
  */
 function displayResults() {
     const { therapists } = state;
-    const { drafts = [], applescript = '' } = state.results || {};
+    const { drafts = [] } = state.results || {};
 
     // Summary
     const totalCount = therapists.length;
@@ -331,19 +351,230 @@ function handleDownloadTable() {
     downloadFile(csvContent, filename, 'text/csv');
 }
 
-/**
- * Download AppleScript file.
- */
-function handleDownloadApplescript() {
-    const { applescript = '' } = state.results || {};
+// ============================================
+// Email Draft Queue
+// ============================================
 
-    if (!applescript) {
-        showStatus(elements.generateStatus, 'No AppleScript available', 'warning');
+/**
+ * Load the set of previously-contacted email addresses from localStorage.
+ * @returns {Set<string>}
+ */
+function loadContactedEmails() {
+    try {
+        const raw = localStorage.getItem(CONTACTED_STORAGE_KEY);
+        if (!raw) return new Set();
+        const parsed = JSON.parse(raw);
+        return new Set(Array.isArray(parsed) ? parsed : []);
+    } catch (error) {
+        console.warn('Failed to load contacted emails:', error);
+        return new Set();
+    }
+}
+
+/**
+ * Persist the set of contacted email addresses.
+ * @param {Set<string>} set
+ */
+function saveContactedEmails(set) {
+    try {
+        localStorage.setItem(CONTACTED_STORAGE_KEY, JSON.stringify([...set]));
+    } catch (error) {
+        console.warn('Failed to save contacted emails:', error);
+    }
+}
+
+/**
+ * Mark a single email address as contacted.
+ * @param {string} email
+ */
+function markEmailContacted(email) {
+    if (!email) return;
+    const set = loadContactedEmails();
+    set.add(email.toLowerCase());
+    saveContactedEmails(set);
+}
+
+/**
+ * Build a mailto: URL, truncating the body if needed to stay within URL limits.
+ * @param {{to: string, subject: string, body: string}} draft
+ * @returns {{url: string, truncated: boolean}}
+ */
+function buildMailtoUrl({ to, subject, body }) {
+    const encodedTo = encodeURIComponent(to || '');
+    const encodedSubject = encodeURIComponent(subject || '');
+    const baseLength = `mailto:${encodedTo}?subject=${encodedSubject}&body=`.length;
+    const budget = MAILTO_MAX_LENGTH - baseLength;
+
+    let bodyToEncode = body || '';
+    let truncated = false;
+    let encodedBody = encodeURIComponent(bodyToEncode);
+
+    if (encodedBody.length > budget) {
+        truncated = true;
+        const markerLength = encodeURIComponent(TRUNCATION_MARKER).length;
+        // Binary-search for the largest prefix of body whose encoded length
+        // plus the encoded truncation marker fits into the budget.
+        let low = 0;
+        let high = bodyToEncode.length;
+        while (low < high) {
+            const mid = Math.ceil((low + high) / 2);
+            const candidate = encodeURIComponent(bodyToEncode.slice(0, mid)).length;
+            if (candidate + markerLength <= budget) {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        bodyToEncode = bodyToEncode.slice(0, low) + TRUNCATION_MARKER;
+        encodedBody = encodeURIComponent(bodyToEncode);
+    }
+
+    return {
+        url: `mailto:${encodedTo}?subject=${encodedSubject}&body=${encodedBody}`,
+        truncated,
+    };
+}
+
+/**
+ * Get the current draft in the queue, or null.
+ * @returns {object|null}
+ */
+function currentQueueDraft() {
+    const { items, index } = state.queue;
+    return items[index] || null;
+}
+
+/**
+ * Open the queue modal, populating it with uncontacted drafts.
+ */
+function openQueue() {
+    const drafts = (state.results && state.results.drafts) || [];
+    if (drafts.length === 0) {
+        showStatus(elements.generateStatus, 'No drafts available. Generate emails first.', 'warning');
         return;
     }
 
-    const filename = `mail_drafts_${new Date().toISOString().split('T')[0]}.applescript`;
-    downloadFile(applescript, filename, 'text/plain');
+    const contacted = loadContactedEmails();
+    const items = drafts.filter(d => d.to && !contacted.has(d.to.toLowerCase()));
+
+    if (items.length === 0) {
+        showStatus(
+            elements.generateStatus,
+            'All therapists from this list were already contacted. Clear your browser storage to start over.',
+            'info'
+        );
+        return;
+    }
+
+    state.queue = { items, index: 0 };
+    elements.queueOverlay.hidden = false;
+    hideStatus(elements.queueStatus);
+    renderQueueItem();
+}
+
+/**
+ * Render the current queue item into the modal.
+ */
+function renderQueueItem() {
+    const draft = currentQueueDraft();
+    if (!draft) {
+        closeQueue();
+        showStatus(elements.generateStatus, '✓ Queue complete.', 'success');
+        return;
+    }
+
+    const { items, index } = state.queue;
+    elements.queuePosition.textContent = String(index + 1);
+    elements.queueTotal.textContent = String(items.length);
+
+    elements.queueTherapist.innerHTML = `
+        <span class="queue-therapist-name">${escapeHtml(draft.therapist_name || draft.to)}</span>
+        <span class="queue-therapist-email">${escapeHtml(draft.to)}</span>
+    `;
+    elements.queueSubject.textContent = draft.subject || '';
+    elements.queueBodyPreview.textContent = draft.body || '';
+
+    const { truncated } = buildMailtoUrl(draft);
+    elements.queueTruncationWarning.hidden = !truncated;
+
+    elements.queueNext.disabled = true;
+    elements.queueOpen.disabled = false;
+    hideStatus(elements.queueStatus);
+}
+
+/**
+ * Trigger the mailto: URL and mark the current email as contacted.
+ */
+function handleQueueOpen() {
+    const draft = currentQueueDraft();
+    if (!draft) return;
+
+    const { url } = buildMailtoUrl(draft);
+
+    // Use an anchor click for best cross-browser reliability with mailto:.
+    const link = document.createElement('a');
+    link.href = url;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    markEmailContacted(draft.to);
+    elements.queueNext.disabled = false;
+    elements.queueOpen.disabled = true;
+    showStatus(
+        elements.queueStatus,
+        'Mail app opened. Click Next when ready for the next therapist.',
+        'info'
+    );
+}
+
+/**
+ * Advance to the next queue item.
+ */
+function handleQueueNext() {
+    state.queue.index += 1;
+    renderQueueItem();
+}
+
+/**
+ * Skip the current therapist without marking them as contacted.
+ */
+function handleQueueSkip() {
+    state.queue.index += 1;
+    renderQueueItem();
+}
+
+/**
+ * Close the queue modal.
+ */
+function closeQueue() {
+    elements.queueOverlay.hidden = true;
+    state.queue = { items: [], index: 0 };
+}
+
+function handleQueueClose() {
+    closeQueue();
+}
+
+/**
+ * Copy the current draft's body to the clipboard.
+ */
+async function handleQueueCopyBody() {
+    const draft = currentQueueDraft();
+    if (!draft) return;
+
+    try {
+        await navigator.clipboard.writeText(draft.body || '');
+        showStatus(elements.queueStatus, '✓ Email body copied to clipboard.', 'success');
+    } catch (error) {
+        console.warn('Clipboard write failed:', error);
+        showStatus(
+            elements.queueStatus,
+            'Could not access clipboard. Select the text in the preview and copy manually.',
+            'warning'
+        );
+    }
 }
 
 // ============================================
@@ -392,9 +623,19 @@ function initEventListeners() {
     // User info form
     elements.userinfoForm.addEventListener('submit', handleGenerateEmails);
 
-    // Download buttons
+    // Download / queue buttons
     elements.downloadTable.addEventListener('click', handleDownloadTable);
-    elements.downloadApplescript.addEventListener('click', handleDownloadApplescript);
+    elements.openQueue.addEventListener('click', openQueue);
+
+    // Queue modal
+    elements.queueClose.addEventListener('click', handleQueueClose);
+    elements.queueOpen.addEventListener('click', handleQueueOpen);
+    elements.queueNext.addEventListener('click', handleQueueNext);
+    elements.queueSkip.addEventListener('click', handleQueueSkip);
+    elements.queueCopyBody.addEventListener('click', handleQueueCopyBody);
+    elements.queueOverlay.addEventListener('click', (e) => {
+        if (e.target === elements.queueOverlay) handleQueueClose();
+    });
 }
 
 // ============================================

--- a/therapist_finder/api/routes/emails.py
+++ b/therapist_finder/api/routes/emails.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter, HTTPException
 from ...config import Settings
 from ...email.generator import EmailGenerator
 from ...models import TherapistData, UserInfo
-from ...utils.applescript_generator import create_applescript_content
 from ..schemas import (
     EmailDraftResponse,
     GenerateRequest,
@@ -58,13 +57,13 @@ def _generate_csv(therapists: list[TherapistResponse]) -> str:
 
 @router.post("/generate", response_model=GenerateResponse)
 async def generate_emails(request: GenerateRequest) -> GenerateResponse:
-    """Generate email drafts and AppleScript for therapists.
+    """Generate email drafts for therapists.
 
     Args:
         request: Therapist list and user information.
 
     Returns:
-        Generated email drafts, AppleScript content, and CSV table.
+        Generated email drafts and CSV table.
 
     Raises:
         HTTPException: If generation fails.
@@ -79,7 +78,6 @@ async def generate_emails(request: GenerateRequest) -> GenerateResponse:
         if not therapists_with_email:
             return GenerateResponse(
                 drafts=[],
-                applescript="",
                 table_csv=_generate_csv(request.therapists),
             )
 
@@ -101,15 +99,11 @@ async def generate_emails(request: GenerateRequest) -> GenerateResponse:
             for d in drafts
         ]
 
-        # Generate AppleScript
-        applescript = create_applescript_content(drafts)
-
         # Generate CSV table
         csv_content = _generate_csv(request.therapists)
 
         return GenerateResponse(
             drafts=draft_responses,
-            applescript=applescript,
             table_csv=csv_content,
         )
 

--- a/therapist_finder/api/schemas.py
+++ b/therapist_finder/api/schemas.py
@@ -58,7 +58,6 @@ class GenerateResponse(BaseModel):
     """Response from generate endpoint."""
 
     drafts: list[EmailDraftResponse]
-    applescript: str
     table_csv: str
 
 


### PR DESCRIPTION
Replace the macOS-only AppleScript download with a sequential mailto:
queue that works on Windows, Linux, and macOS without any install or
auth. Users step through each therapist one at a time: Open in mail
app → Next → (optional) Skip → (optional) Copy body. Already-contacted
email addresses are persisted in localStorage and skipped on reruns,
so re-running the flow only queues new therapists. Long bodies are
safely truncated in the mailto: URL (with a visible warning + Copy
body fallback) to stay within typical OS URL-length limits.

Backend: drop `applescript` from GenerateResponse and remove the
create_applescript_content call from the /emails/generate route. The
CLI `applescript` command and its generator module are unchanged.

https://claude.ai/code/session_0182EpqTeSYkXbVYffjVGBJf