### PR TITLE
Webapp: address search is the default entry, sequential mailto reused

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,8 +20,66 @@
         </header>
 
         <main class="main container">
-            <!-- Step 1: Upload -->
-            <section class="card" id="upload-section">
+            <!-- Step 1: Find nearby therapists by address (default flow) -->
+            <section class="card" id="search-section">
+                <div class="card-header">
+                    <span class="step-badge">1</span>
+                    <h2>Find therapists near you</h2>
+                </div>
+                <div class="card-body">
+                    <form id="search-form" class="form">
+                        <div class="form-group">
+                            <label for="search-address">Address *</label>
+                            <input
+                                type="text"
+                                id="search-address"
+                                name="address"
+                                placeholder="e.g. Kastanienallee 12, 10435 Berlin"
+                                autocomplete="street-address"
+                                required>
+                            <p class="dropzone-hint">
+                                We'll return the N closest psychotherapists / doctors,
+                                sorted by distance to this address.
+                            </p>
+                        </div>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label for="search-max">How many results</label>
+                                <input
+                                    type="number"
+                                    id="search-max"
+                                    name="max_results"
+                                    min="1"
+                                    max="100"
+                                    value="20">
+                            </div>
+                            <div class="form-group">
+                                <label for="search-radius">Radius (km)</label>
+                                <input
+                                    type="number"
+                                    id="search-radius"
+                                    name="radius_km"
+                                    min="1"
+                                    max="50"
+                                    step="0.5"
+                                    value="15">
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-lg" id="search-btn">
+                            <span class="btn-text">Find therapists</span>
+                            <span class="btn-loader" hidden></span>
+                        </button>
+                    </form>
+                    <div class="status" id="search-status" hidden></div>
+                    <p class="dropzone-hint">
+                        Got a list already?
+                        <a href="#" id="toggle-upload">Upload a PDF / text file instead</a>.
+                    </p>
+                </div>
+            </section>
+
+            <!-- Legacy: Upload PDF/TXT (hidden by default, toggled on demand) -->
+            <section class="card" id="upload-section" hidden>
                 <div class="card-header">
                     <span class="step-badge">1</span>
                     <h2>Upload Therapist List</h2>
@@ -45,6 +103,9 @@
                         <span class="btn-loader" hidden></span>
                     </button>
                     <div class="status" id="upload-status" hidden></div>
+                    <p class="dropzone-hint">
+                        <a href="#" id="toggle-search">← Back to address search</a>
+                    </p>
                 </div>
             </section>
 

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -81,6 +81,38 @@ export async function parseFile(file) {
 }
 
 /**
+ * Search for the N closest therapists to a Berlin address.
+ * @param {Object} params
+ * @param {string} params.address - Street address to search around
+ * @param {number} [params.max_results=20] - Return the N closest providers
+ * @param {string} [params.specialty='Psychotherapeut']
+ * @param {number} [params.radius_km=15]
+ * @param {string[]} [params.sources] - Source names (defaults to server-side CI-safe set)
+ * @returns {Promise<Object>} - Search response with ranked therapists
+ */
+export async function searchByAddress({
+    address,
+    max_results = 20,
+    specialty = 'Psychotherapeut',
+    radius_km = 15,
+    sources,
+}) {
+    return request('/therapists/search-by-address', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            address,
+            max_results,
+            specialty,
+            radius_km,
+            ...(sources ? { sources } : {}),
+        }),
+    });
+}
+
+/**
  * Generate email drafts for therapists.
  * @param {Array} therapists - List of therapist objects
  * @param {Object} userInfo - User information

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -3,7 +3,13 @@
  * @module app
  */
 
-import { parseFile, generateEmails, downloadFile, APIError } from './api.js';
+import {
+    APIError,
+    downloadFile,
+    generateEmails,
+    parseFile,
+    searchByAddress,
+} from './api.js';
 
 // ============================================
 // State
@@ -26,7 +32,19 @@ const TRUNCATION_MARKER = '\n\n[… truncated — use "Copy body" to paste full 
 // ============================================
 
 const elements = {
-    // Upload section
+    // Address search section (default)
+    searchSection: document.getElementById('search-section'),
+    searchForm: document.getElementById('search-form'),
+    searchBtn: document.getElementById('search-btn'),
+    searchStatus: document.getElementById('search-status'),
+    searchAddress: document.getElementById('search-address'),
+    searchMax: document.getElementById('search-max'),
+    searchRadius: document.getElementById('search-radius'),
+    toggleUpload: document.getElementById('toggle-upload'),
+    toggleSearch: document.getElementById('toggle-search'),
+
+    // Upload section (legacy fallback)
+    uploadSection: document.getElementById('upload-section'),
     dropzone: document.getElementById('dropzone'),
     fileInput: document.getElementById('file-input'),
     selectedFile: document.getElementById('selected-file'),
@@ -127,6 +145,75 @@ function escapeHtml(text) {
 function formatDate(dateStr) {
     if (!dateStr) return '-';
     return dateStr;
+}
+
+// ============================================
+// Address search (default flow)
+// ============================================
+
+/**
+ * Handle the "Find therapists" form submission.
+ * Calls the backend crawl pipeline with an address and populates the same
+ * state that the PDF-upload path fills, so the downstream email-draft
+ * queue just works.
+ * @param {Event} event - Form submit event
+ */
+async function handleAddressSearch(event) {
+    event.preventDefault();
+    const address = elements.searchAddress.value.trim();
+    if (!address) return;
+
+    const maxResults = Number(elements.searchMax.value) || 20;
+    const radiusKm = Number(elements.searchRadius.value) || 15;
+
+    setButtonLoading(elements.searchBtn, true);
+    showStatus(
+        elements.searchStatus,
+        `Crawling public directories near ${address}…`,
+        'info'
+    );
+
+    try {
+        const result = await searchByAddress({
+            address,
+            max_results: maxResults,
+            radius_km: radiusKm,
+        });
+        state.therapists = result.therapists || [];
+
+        const count = state.therapists.length;
+        const withEmail = state.therapists.filter((t) => t.email).length;
+        showStatus(
+            elements.searchStatus,
+            `✓ ${count} therapists near ${result.origin_address || address} `
+                + `(${withEmail} with email)`,
+            'success'
+        );
+
+        elements.userinfoSection.hidden = false;
+        elements.userinfoSection.scrollIntoView({ behavior: 'smooth' });
+    } catch (error) {
+        console.error('Search error:', error);
+        showStatus(
+            elements.searchStatus,
+            error instanceof APIError
+                ? error.message
+                : 'Search failed. Please try again.',
+            'error'
+        );
+    } finally {
+        setButtonLoading(elements.searchBtn, false);
+    }
+}
+
+/**
+ * Swap between the address-search and file-upload sections.
+ * @param {'search' | 'upload'} target
+ */
+function setEntrySection(target) {
+    const showSearch = target === 'search';
+    elements.searchSection.hidden = !showSearch;
+    elements.uploadSection.hidden = showSearch;
 }
 
 // ============================================
@@ -582,6 +669,17 @@ async function handleQueueCopyBody() {
 // ============================================
 
 function initEventListeners() {
+    // Address search (default flow)
+    elements.searchForm.addEventListener('submit', handleAddressSearch);
+    elements.toggleUpload.addEventListener('click', (e) => {
+        e.preventDefault();
+        setEntrySection('upload');
+    });
+    elements.toggleSearch.addEventListener('click', (e) => {
+        e.preventDefault();
+        setEntrySection('search');
+    });
+
     // Dropzone click
     elements.dropzone.addEventListener('click', (e) => {
         if (e.target !== elements.removeFile && !elements.removeFile.contains(e.target)) {

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -30,12 +30,8 @@ def test_search_by_address_success() -> None:
     )
 
     with (
-        patch(
-            "therapist_finder.api.routes.therapists.Geocoder"
-        ) as mock_geocoder_cls,
-        patch(
-            "therapist_finder.api.routes.therapists._build_source"
-        ) as mock_build,
+        patch("therapist_finder.api.routes.therapists.Geocoder") as mock_geocoder_cls,
+        patch("therapist_finder.api.routes.therapists._build_source") as mock_build,
     ):
         geocoder = mock_geocoder_cls.return_value
         geocoder.geocode.return_value = _fake_location()
@@ -75,9 +71,7 @@ def test_search_by_address_success() -> None:
 
 def test_search_by_address_invalid_address() -> None:
     """Non-Berlin address → 400 with the geocoder's message."""
-    with patch(
-        "therapist_finder.api.routes.therapists.Geocoder"
-    ) as mock_geocoder_cls:
+    with patch("therapist_finder.api.routes.therapists.Geocoder") as mock_geocoder_cls:
         mock_geocoder_cls.return_value.geocode.side_effect = GeocodingError(
             "outside Berlin"
         )
@@ -93,9 +87,7 @@ def test_search_by_address_invalid_address() -> None:
 
 def test_search_by_address_rejects_unknown_sources() -> None:
     """All sources unknown → 400 'No valid sources selected'."""
-    with patch(
-        "therapist_finder.api.routes.therapists.Geocoder"
-    ) as mock_geocoder_cls:
+    with patch("therapist_finder.api.routes.therapists.Geocoder") as mock_geocoder_cls:
         mock_geocoder_cls.return_value.geocode.return_value = _fake_location()
 
         client = TestClient(app)

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -1,0 +1,111 @@
+"""Tests for the /api/therapists/search-by-address endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from therapist_finder.api.main import app
+from therapist_finder.models import TherapistData
+from therapist_finder.sources.geocode import GeocodingError, Location
+
+
+def _fake_location() -> Location:
+    return Location(
+        lat=52.5396, lon=13.4127, display_name="Kastanienallee 12, 10435 Berlin"
+    )
+
+
+def test_search_by_address_success() -> None:
+    """Happy path: geocoder + 1 source → ranked response."""
+    near = TherapistData(
+        name="Dr. Anna Beispiel",
+        address="Kastanienallee 12, 10435 Berlin",
+        email="anna@beispiel.de",
+        telefon="030 1234567",
+        lat=52.5396,
+        lon=13.4127,
+        sources=["osm"],
+    )
+
+    with (
+        patch(
+            "therapist_finder.api.routes.therapists.Geocoder"
+        ) as mock_geocoder_cls,
+        patch(
+            "therapist_finder.api.routes.therapists._build_source"
+        ) as mock_build,
+    ):
+        geocoder = mock_geocoder_cls.return_value
+        geocoder.geocode.return_value = _fake_location()
+
+        class _FakeSource:
+            name = "osm"
+
+            def search(self, params: object) -> list[TherapistData]:
+                return [near]
+
+            def close(self) -> None:
+                return None
+
+        mock_build.side_effect = lambda name, settings: (
+            _FakeSource() if name == "osm" else None
+        )
+
+        client = TestClient(app)
+        resp = client.post(
+            "/api/therapists/search-by-address",
+            json={
+                "address": "Kastanienallee 12, 10435 Berlin",
+                "max_results": 5,
+                "sources": ["osm"],
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["with_email"] == 1
+    assert body["origin_address"] == "Kastanienallee 12, 10435 Berlin"
+    assert body["therapists"][0]["name"] == "Dr. Anna Beispiel"
+    assert body["therapists"][0]["email"] == "anna@beispiel.de"
+    assert body["therapists"][0]["sources"] == ["osm"]
+
+
+def test_search_by_address_invalid_address() -> None:
+    """Non-Berlin address → 400 with the geocoder's message."""
+    with patch(
+        "therapist_finder.api.routes.therapists.Geocoder"
+    ) as mock_geocoder_cls:
+        mock_geocoder_cls.return_value.geocode.side_effect = GeocodingError(
+            "outside Berlin"
+        )
+        client = TestClient(app)
+        resp = client.post(
+            "/api/therapists/search-by-address",
+            json={"address": "Marienplatz, München", "sources": ["osm"]},
+        )
+
+    assert resp.status_code == 400
+    assert "outside Berlin" in resp.json()["detail"]
+
+
+def test_search_by_address_rejects_unknown_sources() -> None:
+    """All sources unknown → 400 'No valid sources selected'."""
+    with patch(
+        "therapist_finder.api.routes.therapists.Geocoder"
+    ) as mock_geocoder_cls:
+        mock_geocoder_cls.return_value.geocode.return_value = _fake_location()
+
+        client = TestClient(app)
+        resp = client.post(
+            "/api/therapists/search-by-address",
+            json={
+                "address": "Kastanienallee 12, 10435 Berlin",
+                "sources": ["does-not-exist"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert "No valid sources" in resp.json()["detail"]

--- a/therapist_finder/api/routes/therapists.py
+++ b/therapist_finder/api/routes/therapists.py
@@ -85,9 +85,7 @@ async def search_by_address(
         raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:  # noqa: BLE001
         geocoder.close()
-        raise HTTPException(
-            status_code=502, detail=f"Geocoding failed: {e}"
-        ) from e
+        raise HTTPException(status_code=502, detail=f"Geocoding failed: {e}") from e
 
     params = SearchParams(
         specialty=request.specialty,

--- a/therapist_finder/api/routes/therapists.py
+++ b/therapist_finder/api/routes/therapists.py
@@ -1,16 +1,142 @@
-"""Therapist parsing endpoints."""
+"""Therapist parsing + address-search endpoints."""
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
 from ...config import Settings
+from ...models import TherapistData
+from ...parsers.arztsuche_api import Arztsuche116117Source
 from ...parsers.pdf_parser import PDFParser
 from ...parsers.text_parser import TextParser
-from ..schemas import ParseResponse, TherapistResponse
+from ...sources.base import SearchParams
+from ...sources.geocode import Geocoder, GeocodingError
+from ...sources.merger import merge_and_rank
+from ...sources.overpass import OverpassSource
+from ...sources.psych_info import PsychInfoSource
+from ...sources.therapie_de import TherapieDeSource
+from ..schemas import (
+    ParseResponse,
+    SearchByAddressRequest,
+    SearchByAddressResponse,
+    TherapistResponse,
+)
 
 router = APIRouter(prefix="/therapists", tags=["therapists"])
+
+
+def _build_source(name: str, settings: Settings) -> object | None:
+    """Instantiate a source by name. Returns None for unknown names."""
+    if name == "116117":
+        return Arztsuche116117Source()
+    if name == "osm":
+        return OverpassSource(
+            endpoint=settings.overpass_endpoint,
+            user_agent=settings.scraper_user_agent,
+        )
+    if name == "psych_info":
+        return PsychInfoSource(
+            user_agent=settings.scraper_user_agent,
+            min_delay_seconds=settings.scraper_min_delay_seconds,
+        )
+    if name == "therapie_de":
+        return TherapieDeSource(
+            user_agent=settings.scraper_user_agent,
+            min_delay_seconds=max(settings.scraper_min_delay_seconds, 3.0),
+        )
+    return None
+
+
+def _therapist_to_response(t: TherapistData) -> TherapistResponse:
+    return TherapistResponse(
+        name=t.name,
+        address=t.address,
+        phone=t.telefon,
+        email=t.email,
+        salutation=t.salutation,
+        distance_km=t.distance_km,
+        sources=list(t.sources),
+    )
+
+
+@router.post("/search-by-address", response_model=SearchByAddressResponse)
+async def search_by_address(
+    request: SearchByAddressRequest,
+) -> SearchByAddressResponse:
+    """Return the N closest providers to a street address.
+
+    Geocodes the input address, queries every enabled source in parallel,
+    merges duplicates across sources, and ranks by haversine distance.
+    """
+    settings = Settings()
+    requested = request.sources or settings.enabled_sources
+
+    geocoder = Geocoder(
+        endpoint=settings.nominatim_endpoint,
+        user_agent=settings.scraper_user_agent,
+        cache_dir=settings.http_cache_dir,
+    )
+    try:
+        origin = geocoder.geocode(request.address)
+    except GeocodingError as e:
+        geocoder.close()
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:  # noqa: BLE001
+        geocoder.close()
+        raise HTTPException(
+            status_code=502, detail=f"Geocoding failed: {e}"
+        ) from e
+
+    params = SearchParams(
+        specialty=request.specialty,
+        lat=origin.lat,
+        lon=origin.lon,
+        radius_km=request.radius_km,
+        limit_per_source=max(request.max_results * 3, 50),
+    )
+
+    sources = [s for s in (_build_source(n, settings) for n in requested) if s]
+    if not sources:
+        geocoder.close()
+        raise HTTPException(status_code=400, detail="No valid sources selected")
+
+    results: dict[str, list[TherapistData]] = {}
+    with ThreadPoolExecutor(max_workers=len(sources)) as pool:
+        futures = {
+            pool.submit(src.search, params): src.name  # type: ignore[attr-defined]
+            for src in sources
+        }
+        for fut in as_completed(futures):
+            name = futures[fut]
+            try:
+                results[name] = fut.result()
+            except Exception:  # noqa: BLE001
+                results[name] = []
+
+    for src in sources:
+        src.close()  # type: ignore[attr-defined]
+
+    merged = merge_and_rank(
+        results,
+        origin.lat,
+        origin.lon,
+        request.max_results,
+        geocoder=geocoder,
+    )
+    geocoder.close()
+
+    responses = [_therapist_to_response(t) for t in merged]
+    with_email = sum(1 for t in merged if t.email)
+    return SearchByAddressResponse(
+        therapists=responses,
+        total=len(responses),
+        with_email=with_email,
+        origin_address=origin.display_name,
+        origin_lat=origin.lat,
+        origin_lon=origin.lon,
+    )
 
 
 @router.post("/parse", response_model=ParseResponse)
@@ -57,16 +183,7 @@ async def parse_file(
         therapists = parser.parse_file(tmp_path)
 
         # Convert to response format
-        therapist_responses = [
-            TherapistResponse(
-                name=t.name,
-                address=t.address,
-                phone=t.telefon,
-                email=t.email,
-                salutation=t.salutation,
-            )
-            for t in therapists
-        ]
+        therapist_responses = [_therapist_to_response(t) for t in therapists]
 
         with_email = sum(1 for t in therapists if t.email)
 

--- a/therapist_finder/api/schemas.py
+++ b/therapist_finder/api/schemas.py
@@ -46,8 +46,7 @@ class SearchByAddressRequest(BaseModel):
     address: str = Field(
         ...,
         description=(
-            "Street address to search around, "
-            "e.g. 'Kastanienallee 12, 10435 Berlin'"
+            "Street address to search around, e.g. 'Kastanienallee 12, 10435 Berlin'"
         ),
     )
     max_results: int = Field(

--- a/therapist_finder/api/schemas.py
+++ b/therapist_finder/api/schemas.py
@@ -28,6 +28,8 @@ class TherapistResponse(BaseModel):
     phone: str | None = None
     email: str | None = None
     salutation: str | None = None
+    distance_km: float | None = None
+    sources: list[str] = []
 
 
 class ParseResponse(BaseModel):
@@ -36,6 +38,43 @@ class ParseResponse(BaseModel):
     therapists: list[TherapistResponse]
     total: int
     with_email: int
+
+
+class SearchByAddressRequest(BaseModel):
+    """Search by address: the webapp's default entry point."""
+
+    address: str = Field(
+        ...,
+        description=(
+            "Street address to search around, "
+            "e.g. 'Kastanienallee 12, 10435 Berlin'"
+        ),
+    )
+    max_results: int = Field(
+        20, ge=1, le=100, description="Return the N closest providers"
+    )
+    specialty: str = Field("Psychotherapeut", description="Specialty filter")
+    radius_km: float = Field(
+        15.0, ge=0.5, le=50.0, description="Per-source search radius"
+    )
+    sources: list[str] | None = Field(
+        None,
+        description=(
+            "Source names to query. Defaults to the CI-safe set configured "
+            "in Settings.enabled_sources when omitted."
+        ),
+    )
+
+
+class SearchByAddressResponse(BaseModel):
+    """Response to a search-by-address request."""
+
+    therapists: list[TherapistResponse]
+    total: int
+    with_email: int
+    origin_address: str
+    origin_lat: float
+    origin_lon: float
 
 
 class EmailDraftResponse(BaseModel):


### PR DESCRIPTION
## Summary

Follow-up to #8. The webapp now opens on an **address input** instead of a PDF dropzone. Submitting calls the new `POST /api/therapists/search-by-address`, which runs the same crawl pipeline as the CLI's `crawl-berlin` command (default sources `116117` + `osm`, geocode via Nominatim, merge + rank by haversine distance) and returns the N closest providers.

The existing user-info form and **sequential mailto queue** are unchanged and pick up the returned therapist list as-is — one email at a time with skip / next / copy-body / open-in-mail.

PDF upload stays reachable as a secondary entry (hidden behind an "Upload a PDF / text file instead" link). Say the word and I'll rip it out.

## Changes

- **Backend**
  - `therapist_finder/api/schemas.py`: `SearchByAddressRequest` + `SearchByAddressResponse`; extended `TherapistResponse` with `distance_km` + `sources`.
  - `therapist_finder/api/routes/therapists.py`: new `POST /therapists/search-by-address` endpoint that builds sources in parallel, calls `merge_and_rank`, and returns ranked `TherapistResponse[]`.
- **Frontend**
  - `frontend/index.html`: address-input card is step 1; PDF dropzone moved to a fallback section toggled via links.
  - `frontend/js/api.js`: `searchByAddress({address, max_results, specialty, radius_km, sources})`.
  - `frontend/js/app.js`: `handleAddressSearch` populates `state.therapists` in the same shape the PDF path did — the rest of the pipeline just works.
- **Tests**
  - `tests/test_api_search.py`: happy path, non-Berlin address rejected, unknown sources rejected.

## Test plan

- [x] `poetry run pytest` — 20/20 green
- [x] `poetry run mypy therapist_finder` — clean
- [x] `poetry run ruff check .` — clean
- [ ] Manual: open the frontend → enter a Berlin address → verify the queue modal opens with the first therapist
- [ ] Deploy preview on Render exposes the new endpoint

https://claude.ai/code/session_013TqWTFW2HCcrPouKcJYgvj