### PR TITLE
fix(api): allow GitHub Pages origin in CORS defaults

### DIFF
--- a/therapist_finder/api/main.py
+++ b/therapist_finder/api/main.py
@@ -23,6 +23,8 @@ _default_origins = [
     "http://localhost:8000",
     "http://127.0.0.1:3000",
     "http://127.0.0.1:8000",
+    # Production frontend hosted on GitHub Pages
+    "https://anneoneone.github.io",
 ]
 _extra_origins = [
     o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()


### PR DESCRIPTION
## Summary

Fixes the "Load failed" the user sees when submitting an address on the deployed webapp.

Render logs confirmed the problem:

```
OPTIONS /api/therapists/search-by-address HTTP/1.1" 400 Bad Request
```

FastAPI's `CORSMiddleware` was rejecting the browser preflight because `https://anneoneone.github.io` (where the frontend is hosted) wasn't in the allowlist. `CORS_ORIGINS` env on Render is `sync: false` and hadn't been populated, so only the four localhost defaults were active.

## Change

Adds `https://anneoneone.github.io` to the built-in `_default_origins` in `therapist_finder/api/main.py`. No env config needed.

## Test plan

- [x] `poetry run pytest` — 20/20 green
- [x] `poetry run ruff check .` — clean
- [ ] After Render redeploys: submitting an address on the webapp returns a ranked therapist list instead of "Load failed".

https://claude.ai/code/session_013TqWTFW2HCcrPouKcJYgvj