### PR TITLE
fix(geocoder): default to Photon instead of Nominatim

### DIFF
--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -190,10 +190,10 @@ class TestTherapieDeSource:
 
 
 class TestGeocoder:
-    """Tests for the Nominatim geocoder wrapper."""
+    """Tests for the Photon + Nominatim geocoder wrapper."""
 
-    def test_geocode_success(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
-        """A Berlin address returns a ``Location`` and caches the response."""
+    def test_nominatim_success(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        """Nominatim endpoint parses the flat-list response shape."""
         httpx_mock.add_response(
             url=httpx.URL(
                 "https://nominatim.example/search",
@@ -225,6 +225,49 @@ class TestGeocoder:
             geocoder.close()
         assert loc.lat == pytest.approx(52.5396)
         assert loc.lon == pytest.approx(13.4127)
+
+    def test_photon_success(self, httpx_mock: HTTPXMock, tmp_path: Path) -> None:
+        """Photon endpoint parses the GeoJSON FeatureCollection response."""
+        httpx_mock.add_response(
+            url=httpx.URL(
+                "https://photon.example/api/",
+                params={
+                    "q": "Kastanienallee 12, 10435 Berlin",
+                    "limit": "1",
+                    "lang": "de",
+                },
+            ),
+            method="GET",
+            json={
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "geometry": {
+                            "type": "Point",
+                            "coordinates": [13.4127, 52.5396],
+                        },
+                        "properties": {
+                            "street": "Kastanienallee",
+                            "housenumber": "12",
+                            "postcode": "10435",
+                            "city": "Berlin",
+                        },
+                    }
+                ],
+            },
+        )
+        geocoder = Geocoder(
+            endpoint="https://photon.example/api/",
+            user_agent=UA,
+            cache_dir=tmp_path,
+        )
+        try:
+            loc = geocoder.geocode("Kastanienallee 12, 10435 Berlin")
+        finally:
+            geocoder.close()
+        assert loc.lat == pytest.approx(52.5396)
+        assert loc.lon == pytest.approx(13.4127)
+        assert "Kastanienallee" in loc.display_name
 
     def test_geocode_outside_berlin_raises(
         self, httpx_mock: HTTPXMock, tmp_path: Path

--- a/therapist_finder/api/routes/therapists.py
+++ b/therapist_finder/api/routes/therapists.py
@@ -74,7 +74,7 @@ async def search_by_address(
     requested = request.sources or settings.enabled_sources
 
     geocoder = Geocoder(
-        endpoint=settings.nominatim_endpoint,
+        endpoint=settings.geocoder_endpoint,
         user_agent=settings.scraper_user_agent,
         cache_dir=settings.http_cache_dir,
     )

--- a/therapist_finder/cli.py
+++ b/therapist_finder/cli.py
@@ -301,7 +301,7 @@ def crawl_berlin(
 
     console.print(f"\n[bold blue]Geocoding {address!r}...[/bold blue]")
     geocoder = Geocoder(
-        endpoint=settings.nominatim_endpoint,
+        endpoint=settings.geocoder_endpoint,
         user_agent=settings.scraper_user_agent,
         cache_dir=settings.http_cache_dir,
     )

--- a/therapist_finder/config.py
+++ b/therapist_finder/config.py
@@ -73,9 +73,14 @@ class Settings(BaseSettings):
         default="https://overpass-api.de/api/interpreter",
         description="Overpass API endpoint",
     )
-    nominatim_endpoint: str = Field(
-        default="https://nominatim.openstreetmap.org/search",
-        description="Nominatim geocoding endpoint",
+    geocoder_endpoint: str = Field(
+        default="https://photon.komoot.io/api/",
+        description=(
+            "Geocoding endpoint. Provider is detected by URL: 'photon' in the "
+            "host switches to Photon's GeoJSON shape; anything else is treated "
+            "as Nominatim. Defaults to Photon because the public Nominatim "
+            "instance rate-limits shared cloud IPs aggressively."
+        ),
     )
     http_cache_dir: Path | None = Field(
         default=Path(".cache/therapist-finder"),

--- a/therapist_finder/sources/geocode.py
+++ b/therapist_finder/sources/geocode.py
@@ -1,4 +1,4 @@
-"""Geocoding helpers backed by Nominatim + Haversine distance."""
+"""Geocoding helpers (Photon by default, Nominatim supported) + haversine."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import json
 from math import asin, cos, radians, sin, sqrt
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 import httpx
@@ -15,6 +15,8 @@ from therapist_finder.sources.rate_limit import RateLimiter
 
 BERLIN_LAT_RANGE = (52.3, 52.7)
 BERLIN_LON_RANGE = (13.0, 13.8)
+
+Provider = Literal["photon", "nominatim"]
 
 
 @dataclass(frozen=True)
@@ -30,8 +32,18 @@ class GeocodingError(RuntimeError):
     """Raised when an address cannot be geocoded or falls outside Berlin."""
 
 
+def _detect_provider(endpoint: str) -> Provider:
+    return "photon" if "photon" in endpoint.lower() else "nominatim"
+
+
 class Geocoder:
-    """Thin wrapper around Nominatim with disk-cache + 1 rps rate limit."""
+    """Geocoder supporting Photon (default) and Nominatim.
+
+    Provider is detected by the endpoint URL: a ``photon`` host selects
+    Photon's GeoJSON response shape, anything else is treated as Nominatim.
+    Both providers use OSM data; Photon (komoot.io) has much laxer
+    per-IP rate limits and is the safer default for shared cloud IPs.
+    """
 
     def __init__(
         self,
@@ -43,12 +55,13 @@ class Geocoder:
         """Initialise the geocoder.
 
         Args:
-            endpoint: Full Nominatim ``/search`` URL.
-            user_agent: Identifying User-Agent required by Nominatim ToS.
+            endpoint: Full geocoder URL (Photon ``/api/`` or Nominatim ``/search``).
+            user_agent: Identifying User-Agent.
             cache_dir: If given, JSON responses are cached there by address.
             client: Optional pre-built ``httpx.Client`` (useful in tests).
         """
         self._endpoint = endpoint
+        self._provider: Provider = _detect_provider(endpoint)
         self._cache_dir = cache_dir
         if cache_dir is not None:
             cache_dir.mkdir(parents=True, exist_ok=True)
@@ -57,51 +70,36 @@ class Geocoder:
             timeout=20.0,
         )
         self._owns_client = client is None
-        self._rate_limiter = RateLimiter(min_delay_seconds=1.0)
+        # Photon publishes no hard rate limit; stay polite with a small delay.
+        # Nominatim requires ≤1 rps.
+        min_delay = 0.2 if self._provider == "photon" else 1.0
+        self._rate_limiter = RateLimiter(min_delay_seconds=min_delay)
         self._host = urlparse(endpoint).netloc
 
     def geocode(self, address: str, *, require_berlin: bool = True) -> Location:
-        """Geocode ``address`` using Nominatim.
+        """Geocode ``address`` using the configured provider.
 
         Raises:
             GeocodingError: If no match is found or the result lies outside
                 Berlin (when ``require_berlin`` is True).
         """
-        key = address.strip().lower()
+        key = f"{self._provider}:{address.strip().lower()}"
         cached = self._read_cache(key)
         if cached is None:
             self._rate_limiter.wait(self._host)
-            resp = self._client.get(
-                self._endpoint,
-                params={
-                    "q": address,
-                    "format": "jsonv2",
-                    "limit": 1,
-                    "addressdetails": 1,
-                    "countrycodes": "de",
-                },
-            )
+            resp = self._client.get(self._endpoint, params=self._params(address))
             resp.raise_for_status()
             payload = resp.json()
             self._write_cache(key, payload)
         else:
             payload = cached
 
-        if not payload:
-            raise GeocodingError(f"No geocoding result for address: {address!r}")
-
-        top: dict[str, Any] = payload[0]
-        lat = float(top["lat"])
-        lon = float(top["lon"])
+        lat, lon, display_name = self._parse(payload, address)
         if require_berlin and not _is_in_berlin(lat, lon):
             raise GeocodingError(
                 f"Address {address!r} geocoded outside Berlin (lat={lat}, lon={lon})"
             )
-        return Location(
-            lat=lat,
-            lon=lon,
-            display_name=top.get("display_name", address),
-        )
+        return Location(lat=lat, lon=lon, display_name=display_name)
 
     def close(self) -> None:
         """Close the underlying HTTP client if we own it."""
@@ -116,23 +114,54 @@ class Geocoder:
         """Context manager exit closes the HTTP client."""
         self.close()
 
+    def _params(self, address: str) -> dict[str, Any]:
+        if self._provider == "photon":
+            return {"q": address, "limit": 1, "lang": "de"}
+        return {
+            "q": address,
+            "format": "jsonv2",
+            "limit": 1,
+            "addressdetails": 1,
+            "countrycodes": "de",
+        }
+
+    def _parse(self, payload: Any, address: str) -> tuple[float, float, str]:
+        if self._provider == "photon":
+            features = (payload or {}).get("features") or []
+            if not features:
+                raise GeocodingError(f"No geocoding result for address: {address!r}")
+            top = features[0]
+            coords = top.get("geometry", {}).get("coordinates") or []
+            if len(coords) < 2:
+                raise GeocodingError(f"Malformed Photon response for {address!r}")
+            lon, lat = float(coords[0]), float(coords[1])
+            display_name = _photon_display_name(top.get("properties", {})) or address
+            return lat, lon, display_name
+
+        # Nominatim
+        if not payload:
+            raise GeocodingError(f"No geocoding result for address: {address!r}")
+        top = payload[0]
+        lat = float(top["lat"])
+        lon = float(top["lon"])
+        return lat, lon, top.get("display_name", address)
+
     def _cache_path(self, key: str) -> Path | None:
         if self._cache_dir is None:
             return None
         safe = "".join(c if c.isalnum() else "_" for c in key)[:120]
         return self._cache_dir / f"geocode_{safe}.json"
 
-    def _read_cache(self, key: str) -> list[dict[str, Any]] | None:
+    def _read_cache(self, key: str) -> Any | None:
         path = self._cache_path(key)
         if path is None or not path.exists():
             return None
         try:
-            data: list[dict[str, Any]] = json.loads(path.read_text("utf-8"))
-            return data
+            return json.loads(path.read_text("utf-8"))
         except (json.JSONDecodeError, OSError):
             return None
 
-    def _write_cache(self, key: str, payload: list[dict[str, Any]]) -> None:
+    def _write_cache(self, key: str, payload: Any) -> None:
         path = self._cache_path(key)
         if path is None:
             return
@@ -156,6 +185,17 @@ def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     dlambda = radians(lon2 - lon1)
     a = sin(dphi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(dlambda / 2) ** 2
     return 2 * r * asin(sqrt(a))
+
+
+def _photon_display_name(props: dict[str, Any]) -> str:
+    parts = [
+        props.get("street"),
+        props.get("housenumber"),
+        props.get("postcode"),
+        props.get("city") or props.get("name"),
+    ]
+    flat = " ".join(str(p) for p in parts if p)
+    return flat.strip()
 
 
 def _is_in_berlin(lat: float, lon: float) -> bool:


### PR DESCRIPTION
## Summary

Fixes the 429 the user saw in the deployed webapp:

```
Geocoding failed: Client error '429 Too many requests' for url
https://nominatim.openstreetmap.org/search?q=Hobrechtstr…
```

Public Nominatim rate-limits shared cloud IPs aggressively. Switching the default to **Photon** (komoot.io) — same OSM data, far looser per-IP limits.

## Change

- `therapist_finder/sources/geocode.py`: `Geocoder` now detects provider by endpoint URL. Photon returns GeoJSON, Nominatim returns a flat list; the class branches on both request params and response parsing. Cache key is namespaced by provider so switching doesn't hand back stale payloads.
- `therapist_finder/config.py`: rename `nominatim_endpoint` → `geocoder_endpoint`, default `https://photon.komoot.io/api/`. (Env var: `THERAPIST_FINDER_GEOCODER_ENDPOINT`.)
- `cli.py` + `api/routes/therapists.py`: use the new setting.
- Tests: add `test_photon_success`, keep the Nominatim happy-path test with an explicit Nominatim URL.

## Test plan

- [x] `poetry run pytest` — 21/21 green (new Photon test included)
- [x] `poetry run mypy therapist_finder` — clean
- [x] `poetry run ruff check .` — clean
- [ ] After Render redeploys: submitting a Berlin address on the webapp resolves via Photon and returns a ranked list

https://claude.ai/code/session_013TqWTFW2HCcrPouKcJYgvj