### PR TITLE
feat(search): add doctor-specialty filter to search flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -38,9 +38,33 @@
                                 autocomplete="street-address"
                                 required>
                             <p class="dropzone-hint">
-                                We'll return the N closest psychotherapists / doctors,
-                                sorted by distance to this address.
+                                We'll return the N closest providers of the
+                                chosen specialty, sorted by distance to this
+                                address.
                             </p>
+                        </div>
+                        <div class="form-group">
+                            <label for="search-specialty">Doctor kind</label>
+                            <select id="search-specialty" name="specialty">
+                                <!-- Options are populated from
+                                     /api/therapists/specialties on load;
+                                     the fallback list below ships with the
+                                     static site so the form still works
+                                     before the API replies. -->
+                                <option value="psychotherapie" selected>Psychotherapie</option>
+                                <option value="kinder_jugend_psychotherapie">Kinder- &amp; Jugendpsychotherapie</option>
+                                <option value="psychiatrie">Psychiatrie</option>
+                                <option value="kinderarzt">Kinder- &amp; Jugendmedizin</option>
+                                <option value="allgemeinmedizin">Allgemeinmedizin / Hausarzt</option>
+                                <option value="hno">HNO (Hals-Nasen-Ohren)</option>
+                                <option value="gynaekologie">Gynäkologie</option>
+                                <option value="dermatologie">Dermatologie (Haut)</option>
+                                <option value="augenarzt">Augenheilkunde</option>
+                                <option value="orthopaedie">Orthopädie</option>
+                                <option value="zahnarzt">Zahnarzt</option>
+                                <option value="heilpraktiker">Heilpraktiker:in (Psychotherapie)</option>
+                                <option value="all">Alle Ärzte &amp; Therapeut:innen</option>
+                            </select>
                         </div>
                         <div class="form-row">
                             <div class="form-group">
@@ -177,6 +201,7 @@
                             <thead>
                                 <tr>
                                     <th>Name</th>
+                                    <th>Specialty</th>
                                     <th>Email</th>
                                     <th>Phone</th>
                                     <th>Address</th>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -85,7 +85,7 @@ export async function parseFile(file) {
  * @param {Object} params
  * @param {string} params.address - Street address to search around
  * @param {number} [params.max_results=20] - Return the N closest providers
- * @param {string} [params.specialty='Psychotherapeut']
+ * @param {string} [params.specialty='psychotherapie'] - Specialty slug (see listSpecialties)
  * @param {number} [params.radius_km=15]
  * @param {string[]} [params.sources] - Source names (defaults to server-side CI-safe set)
  * @returns {Promise<Object>} - Search response with ranked therapists
@@ -93,7 +93,7 @@ export async function parseFile(file) {
 export async function searchByAddress({
     address,
     max_results = 20,
-    specialty = 'Psychotherapeut',
+    specialty = 'psychotherapie',
     radius_km = 15,
     sources,
 }) {
@@ -110,6 +110,14 @@ export async function searchByAddress({
             ...(sources ? { sources } : {}),
         }),
     });
+}
+
+/**
+ * Fetch the catalog of selectable specialties (for the search dropdown).
+ * @returns {Promise<{specialties: Array<{key: string, label: string}>, default: string}>}
+ */
+export async function listSpecialties() {
+    return request('/therapists/specialties');
 }
 
 /**

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -7,6 +7,7 @@ import {
     APIError,
     downloadFile,
     generateEmails,
+    listSpecialties,
     parseFile,
     searchByAddress,
 } from './api.js';
@@ -40,6 +41,7 @@ const elements = {
     searchAddress: document.getElementById('search-address'),
     searchMax: document.getElementById('search-max'),
     searchRadius: document.getElementById('search-radius'),
+    searchSpecialty: document.getElementById('search-specialty'),
     toggleUpload: document.getElementById('toggle-upload'),
     toggleSearch: document.getElementById('toggle-search'),
 
@@ -165,11 +167,15 @@ async function handleAddressSearch(event) {
 
     const maxResults = Number(elements.searchMax.value) || 20;
     const radiusKm = Number(elements.searchRadius.value) || 15;
+    const specialty = elements.searchSpecialty?.value || 'psychotherapie';
+    const specialtyLabel =
+        elements.searchSpecialty?.selectedOptions?.[0]?.textContent?.trim()
+        || specialty;
 
     setButtonLoading(elements.searchBtn, true);
     showStatus(
         elements.searchStatus,
-        `Crawling public directories near ${address}…`,
+        `Crawling public directories near ${address} for ${specialtyLabel}…`,
         'info'
     );
 
@@ -178,6 +184,7 @@ async function handleAddressSearch(event) {
             address,
             max_results: maxResults,
             radius_km: radiusKm,
+            specialty,
         });
         state.therapists = result.therapists || [];
         state.results = null;
@@ -185,11 +192,12 @@ async function handleAddressSearch(event) {
         const total = state.therapists.length;
         const withEmail = state.therapists.filter((t) => t.email).length;
         const originLabel = result.origin_address || address;
+        const specLabel = result.specialty_label || specialtyLabel;
         showStatus(
             elements.searchStatus,
-            `✓ ${withEmail} contactable therapist${withEmail === 1 ? '' : 's'} `
-                + `near ${originLabel} (of ${total} found; only those with an `
-                + `email can receive a mailto draft)`,
+            `✓ ${total} ${specLabel} provider${total === 1 ? '' : 's'} `
+                + `near ${originLabel} (${withEmail} with email; only those `
+                + `can receive a mailto draft)`,
             'success'
         );
 
@@ -405,9 +413,11 @@ function renderTherapists() {
             const hasEmail = !!therapist.email;
             const statusClass = hasEmail ? 'ready' : 'no-email';
             const statusText = hasEmail ? 'Ready' : 'No Email';
+            const specialty = therapist.specialty_label || therapist.specialty || '';
             return `
                 <tr>
                     <td>${escapeHtml(therapist.name)}</td>
+                    <td>${escapeHtml(specialty) || '<span class="text-muted">—</span>'}</td>
                     <td>${escapeHtml(therapist.email) || '<span class="text-muted">—</span>'}</td>
                     <td>${escapeHtml(therapist.phone) || '<span class="text-muted">—</span>'}</td>
                     <td>${escapeHtml(therapist.address) || '<span class="text-muted">—</span>'}</td>
@@ -416,6 +426,33 @@ function renderTherapists() {
             `;
         })
         .join('');
+}
+
+/**
+ * Populate the specialty dropdown from the backend catalog. Falls back
+ * silently to the static options baked into index.html if the API is
+ * unreachable (e.g. during local file:// testing).
+ */
+async function loadSpecialtyOptions() {
+    const select = elements.searchSpecialty;
+    if (!select) return;
+    try {
+        const { specialties = [], default: defaultKey } = await listSpecialties();
+        if (!specialties.length) return;
+        const previous = select.value;
+        select.innerHTML = specialties
+            .map(
+                (s) =>
+                    `<option value="${escapeHtml(s.key)}">${escapeHtml(s.label)}</option>`,
+            )
+            .join('');
+        const desired = previous && specialties.some((s) => s.key === previous)
+            ? previous
+            : defaultKey;
+        if (desired) select.value = desired;
+    } catch (error) {
+        console.warn('Failed to load specialties, keeping static options:', error);
+    }
 }
 
 /**
@@ -442,9 +479,10 @@ function handleDownloadTable() {
     } else {
         // Fallback: generate client-side
         const { therapists } = state;
-        const headers = ['Name', 'Email', 'Phone', 'Address'];
+        const headers = ['Name', 'Specialty', 'Email', 'Phone', 'Address'];
         const rows = therapists.map(t => [
             t.name || '',
+            t.specialty_label || t.specialty || '',
             t.email || '',
             t.phone || '',
             t.address || '',
@@ -766,6 +804,7 @@ function initEventListeners() {
 
 function init() {
     initEventListeners();
+    loadSpecialtyOptions();
     console.log('Therapist Finder initialized');
 }
 

--- a/tests/test_api_search.py
+++ b/tests/test_api_search.py
@@ -24,6 +24,7 @@ def test_search_by_address_success() -> None:
         address="Kastanienallee 12, 10435 Berlin",
         email="anna@beispiel.de",
         telefon="030 1234567",
+        therapieform=["Verhaltenstherapie"],
         lat=52.5396,
         lon=13.4127,
         sources=["osm"],
@@ -56,6 +57,7 @@ def test_search_by_address_success() -> None:
                 "address": "Kastanienallee 12, 10435 Berlin",
                 "max_results": 5,
                 "sources": ["osm"],
+                "specialty": "psychotherapie",
             },
         )
 
@@ -64,9 +66,77 @@ def test_search_by_address_success() -> None:
     assert body["total"] == 1
     assert body["with_email"] == 1
     assert body["origin_address"] == "Kastanienallee 12, 10435 Berlin"
+    assert body["specialty"] == "psychotherapie"
+    assert body["specialty_label"] == "Psychotherapie"
     assert body["therapists"][0]["name"] == "Dr. Anna Beispiel"
     assert body["therapists"][0]["email"] == "anna@beispiel.de"
     assert body["therapists"][0]["sources"] == ["osm"]
+    assert body["therapists"][0]["specialty"] == "psychotherapie"
+
+
+def test_search_by_address_filters_by_specialty() -> None:
+    """Picking 'hno' drops a psychotherapist and keeps the HNO practice."""
+    psycho = TherapistData(
+        name="Dr. Anna Beispiel",
+        address="Kastanienallee 12, 10435 Berlin",
+        therapieform=["Verhaltenstherapie"],
+        lat=52.5396,
+        lon=13.4127,
+        sources=["osm"],
+    )
+    hno = TherapistData(
+        name="HNO-Praxis Kreuzberg-Süd",
+        address="Gneisenaustraße 44, 10961 Berlin",
+        lat=52.4930,
+        lon=13.3890,
+        sources=["osm"],
+    )
+
+    with (
+        patch("therapist_finder.api.routes.therapists.Geocoder") as mock_geocoder_cls,
+        patch("therapist_finder.api.routes.therapists._build_source") as mock_build,
+    ):
+        mock_geocoder_cls.return_value.geocode.return_value = _fake_location()
+
+        class _FakeSource:
+            name = "osm"
+
+            def search(self, params: object) -> list[TherapistData]:
+                return [psycho, hno]
+
+            def close(self) -> None:
+                return None
+
+        mock_build.side_effect = lambda name, settings: (
+            _FakeSource() if name == "osm" else None
+        )
+
+        client = TestClient(app)
+        resp = client.post(
+            "/api/therapists/search-by-address",
+            json={
+                "address": "Kastanienallee 12, 10435 Berlin",
+                "max_results": 10,
+                "sources": ["osm"],
+                "specialty": "hno",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [t["name"] for t in body["therapists"]] == ["HNO-Praxis Kreuzberg-Süd"]
+    assert body["specialty"] == "hno"
+
+
+def test_list_specialties_endpoint() -> None:
+    """The /specialties endpoint lists the options for the UI dropdown."""
+    client = TestClient(app)
+    resp = client.get("/api/therapists/specialties")
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = {s["key"] for s in body["specialties"]}
+    assert {"psychotherapie", "hno", "all"}.issubset(keys)
+    assert body["default"] == "psychotherapie"
 
 
 def test_search_by_address_invalid_address() -> None:

--- a/tests/test_specialties.py
+++ b/tests/test_specialties.py
@@ -1,0 +1,90 @@
+"""Tests for the normalized specialty registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from therapist_finder.models import TherapistData
+from therapist_finder.sources import specialties
+
+
+def _mk(name: str, *therapieform: str) -> TherapistData:
+    return TherapistData(name=name, therapieform=list(therapieform))
+
+
+class TestResolve:
+    def test_resolves_by_slug(self) -> None:
+        assert specialties.resolve("psychotherapie").key == "psychotherapie"
+        assert specialties.resolve("hno").key == "hno"
+        assert specialties.resolve("all").key == "all"
+
+    def test_resolves_legacy_german_label(self) -> None:
+        """Old clients sending ``'Psychotherapeut'`` still get the right spec."""
+        assert specialties.resolve("Psychotherapeut").key == "psychotherapie"
+        assert specialties.resolve("Psychiater").key == "psychiatrie"
+
+    def test_empty_falls_back_to_default(self) -> None:
+        assert specialties.resolve("").key == specialties.DEFAULT_KEY
+        assert specialties.resolve(None).key == specialties.DEFAULT_KEY
+
+    def test_unknown_falls_back_to_default(self) -> None:
+        assert specialties.resolve("totally-unknown-xyz").key == specialties.DEFAULT_KEY
+
+
+class TestMatches:
+    @pytest.mark.parametrize(
+        ("specialty_key", "therapist", "expected"),
+        [
+            ("psychotherapie", _mk("Psychotherapeutische Praxis"), True),
+            ("psychotherapie", _mk("HNO-Praxis Kreuzberg-Süd"), False),
+            ("hno", _mk("HNO-Praxis Kreuzberg-Süd"), True),
+            ("hno", _mk("Praxis für Hals-Nasen-Ohrenheilkunde"), True),
+            (
+                "kinderarzt",
+                _mk("Praxis für Kinder-, Jugend- und Familienmedizin"),
+                True,
+            ),
+            ("psychiatrie", _mk("FÄ für Psychiatrie und Psychotherapie"), True),
+            (
+                "kinder_jugend_psychotherapie",
+                _mk("Praxis für Kinder- und Jugendpsychotherapie"),
+                True,
+            ),
+            ("kinder_jugend_psychotherapie", _mk("Allgemeine Psychiatrie"), False),
+            ("all", _mk("Anything at all"), True),
+        ],
+    )
+    def test_matches(
+        self, specialty_key: str, therapist: TherapistData, expected: bool
+    ) -> None:
+        spec = specialties.SPECIALTIES[specialty_key]
+        assert specialties.matches(spec, therapist) is expected
+
+
+class TestInferKey:
+    def test_infers_hno_from_name(self) -> None:
+        assert specialties.infer_key(_mk("HNO-Praxis Kreuzberg")) == "hno"
+
+    def test_infers_psychotherapie_from_therapieform(self) -> None:
+        t = _mk("Dr. Beispiel", "Verhaltenstherapie")
+        assert specialties.infer_key(t) == "psychotherapie"
+
+    def test_unknown_returns_none(self) -> None:
+        assert specialties.infer_key(_mk("Gemeinschaftspraxis Dr. Pustelnik")) is None
+
+
+class TestFilterResults:
+    def test_filters_out_non_matching(self) -> None:
+        spec = specialties.SPECIALTIES["psychotherapie"]
+        therapists = [
+            _mk("Psychotherapeutische Praxis"),
+            _mk("HNO-Praxis Kreuzberg-Süd"),
+            _mk("Praxis für Kinder-, Jugend- und Familienmedizin"),
+        ]
+        filtered = specialties.filter_results(spec, therapists)
+        assert [t.name for t in filtered] == ["Psychotherapeutische Praxis"]
+
+    def test_all_is_passthrough(self) -> None:
+        spec = specialties.SPECIALTIES["all"]
+        therapists = [_mk("HNO-Praxis"), _mk("Dr. Beispiel")]
+        assert specialties.filter_results(spec, therapists) == therapists

--- a/therapist_finder/api/routes/therapists.py
+++ b/therapist_finder/api/routes/therapists.py
@@ -11,6 +11,7 @@ from ...models import TherapistData
 from ...parsers.arztsuche_api import Arztsuche116117Source
 from ...parsers.pdf_parser import PDFParser
 from ...parsers.text_parser import TextParser
+from ...sources import specialties
 from ...sources.base import SearchParams
 from ...sources.geocode import Geocoder, GeocodingError
 from ...sources.merger import merge_and_rank
@@ -21,6 +22,8 @@ from ..schemas import (
     ParseResponse,
     SearchByAddressRequest,
     SearchByAddressResponse,
+    SpecialtiesResponse,
+    SpecialtyOption,
     TherapistResponse,
 )
 
@@ -50,12 +53,16 @@ def _build_source(name: str, settings: Settings) -> object | None:
 
 
 def _therapist_to_response(t: TherapistData) -> TherapistResponse:
+    key = t.specialty or specialties.infer_key(t)
+    label = specialties.SPECIALTIES[key].label if key in specialties.SPECIALTIES else None
     return TherapistResponse(
         name=t.name,
         address=t.address,
         phone=t.telefon,
         email=t.email,
         salutation=t.salutation,
+        specialty=key,
+        specialty_label=label,
         distance_km=t.distance_km,
         sources=list(t.sources),
     )
@@ -87,8 +94,9 @@ async def search_by_address(
         geocoder.close()
         raise HTTPException(status_code=502, detail=f"Geocoding failed: {e}") from e
 
+    spec = specialties.resolve(request.specialty)
     params = SearchParams(
-        specialty=request.specialty,
+        specialty=spec.key,
         lat=origin.lat,
         lon=origin.lon,
         radius_km=request.radius_km,
@@ -116,14 +124,32 @@ async def search_by_address(
     for src in sources:
         src.close()  # type: ignore[attr-defined]
 
+    # Tag every hit with its inferred normalized specialty before we
+    # filter, so the post-filter can lean on a single stable field rather
+    # than re-running regexes per-source.
+    tagged: dict[str, list[TherapistData]] = {}
+    for src_name, entries in results.items():
+        tagged[src_name] = [
+            (
+                e.model_copy(update={"specialty": specialties.infer_key(e)})
+                if e.specialty is None
+                else e
+            )
+            for e in entries
+        ]
+
     merged = merge_and_rank(
-        results,
+        tagged,
         origin.lat,
         origin.lon,
-        request.max_results,
+        # Over-fetch so the post-filter has room to drop non-matching hits
+        # without starving the response.
+        request.max_results * 4 if not specialties.is_all(spec) else request.max_results,
         geocoder=geocoder,
     )
     geocoder.close()
+
+    merged = specialties.filter_results(spec, merged)[: request.max_results]
 
     responses = [_therapist_to_response(t) for t in merged]
     with_email = sum(1 for t in merged if t.email)
@@ -134,6 +160,20 @@ async def search_by_address(
         origin_address=origin.display_name,
         origin_lat=origin.lat,
         origin_lon=origin.lon,
+        specialty=spec.key,
+        specialty_label=spec.label,
+    )
+
+
+@router.get("/specialties", response_model=SpecialtiesResponse)
+async def list_specialties() -> SpecialtiesResponse:
+    """Return the specialties offered in the search dropdown."""
+    return SpecialtiesResponse(
+        specialties=[
+            SpecialtyOption(key=s.key, label=s.label)
+            for s in specialties.all_specialties()
+        ],
+        default=specialties.DEFAULT_KEY,
     )
 
 

--- a/therapist_finder/api/schemas.py
+++ b/therapist_finder/api/schemas.py
@@ -28,6 +28,8 @@ class TherapistResponse(BaseModel):
     phone: str | None = None
     email: str | None = None
     salutation: str | None = None
+    specialty: str | None = None
+    specialty_label: str | None = None
     distance_km: float | None = None
     sources: list[str] = []
 
@@ -52,7 +54,14 @@ class SearchByAddressRequest(BaseModel):
     max_results: int = Field(
         20, ge=1, le=100, description="Return the N closest providers"
     )
-    specialty: str = Field("Psychotherapeut", description="Specialty filter")
+    specialty: str = Field(
+        "psychotherapie",
+        description=(
+            "Specialty filter. Accepts a slug from the /specialties registry "
+            "(e.g. 'psychotherapie', 'hno', 'all') or a legacy German label "
+            "like 'Psychotherapeut'."
+        ),
+    )
     radius_km: float = Field(
         15.0, ge=0.5, le=50.0, description="Per-source search radius"
     )
@@ -74,6 +83,22 @@ class SearchByAddressResponse(BaseModel):
     origin_address: str
     origin_lat: float
     origin_lon: float
+    specialty: str | None = None
+    specialty_label: str | None = None
+
+
+class SpecialtyOption(BaseModel):
+    """A selectable specialty for the search UI dropdown."""
+
+    key: str
+    label: str
+
+
+class SpecialtiesResponse(BaseModel):
+    """List of selectable specialties, in display order."""
+
+    specialties: list[SpecialtyOption]
+    default: str
 
 
 class EmailDraftResponse(BaseModel):

--- a/therapist_finder/models.py
+++ b/therapist_finder/models.py
@@ -38,6 +38,7 @@ class TherapistData(BaseModel):
     website: str | None = None
     languages: list[str] = []
     insurance_type: InsuranceType | None = None
+    specialty: str | None = None
     lat: float | None = None
     lon: float | None = None
     distance_km: float | None = None

--- a/therapist_finder/parsers/arztsuche_api.py
+++ b/therapist_finder/parsers/arztsuche_api.py
@@ -210,6 +210,7 @@ class Arztsuche116117Source:
         """
         from therapist_finder.models import TherapistData
         from therapist_finder.sources.base import SearchParams as SrcParams
+        from therapist_finder.sources.specialties import resolve
 
         if not isinstance(params, SrcParams):
             raise TypeError(
@@ -220,7 +221,7 @@ class Arztsuche116117Source:
         radius = max(1, min(100, int(round(params.radius_km))))
         max_results = max(1, min(50, params.limit_per_source))
         search_data = {
-            "specialty": params.specialty,
+            "specialty": resolve(params.specialty).de_label,
             "lat": params.lat,
             "lon": params.lon,
             "radius": radius,

--- a/therapist_finder/sources/merger.py
+++ b/therapist_finder/sources/merger.py
@@ -122,6 +122,7 @@ def _merge_one(existing: TherapistData, new: TherapistData) -> TherapistData:
             "sprechzeiten": _merge_list(existing.sprechzeiten, new.sprechzeiten),
             "languages": _merge_list(existing.languages, new.languages),
             "insurance_type": existing.insurance_type or new.insurance_type,
+            "specialty": existing.specialty or new.specialty,
             "lat": existing.lat if existing.lat is not None else new.lat,
             "lon": existing.lon if existing.lon is not None else new.lon,
             "sources": merged_sources,

--- a/therapist_finder/sources/overpass.py
+++ b/therapist_finder/sources/overpass.py
@@ -9,14 +9,9 @@ import httpx
 
 from therapist_finder.models import TherapistData
 from therapist_finder.sources.base import SearchParams, TherapistSource
+from therapist_finder.sources.specialties import is_all, resolve
 
 logger = logging.getLogger(__name__)
-
-_SPECIALTY_KEYWORDS = {
-    "psychotherapeut": ("psychotherapist",),
-    "psychiater": ("psychiatrist",),
-    "arzt": ("doctor",),
-}
 
 
 class OverpassSource(TherapistSource):
@@ -67,21 +62,30 @@ class OverpassSource(TherapistSource):
             self._client.close()
 
     def _build_query(self, params: SearchParams) -> str:
-        keywords = _keywords_for(params.specialty)
-        # Match psychotherapist, doctor, etc. via both ``healthcare`` and
-        # ``amenity`` tags; use a regex alternation to keep the query short.
-        regex = "|".join(keywords)
+        spec = resolve(params.specialty)
+        # Match the specialty against both the ``healthcare`` /
+        # ``healthcare:speciality`` tags and the generic
+        # ``amenity=doctors`` hits. For the catch-all we keep the generic
+        # amenity fallback; for a specific specialty we only include it
+        # when the dictionary says "doctor" is one of its OSM aliases, to
+        # avoid pulling HNO/Pädiatrie/... into e.g. a Psychotherapie query.
+        regex = "|".join(spec.osm_values) or spec.key
         radius_m = int(params.radius_km * 1000)
-        return (
+        q = (
             "[out:json][timeout:45];"
             "("
-            f'nwr["healthcare"~"{regex}"]'
+            f'nwr["healthcare"~"{regex}",i]'
             f"(around:{radius_m},{params.lat},{params.lon});"
-            f'nwr["amenity"="doctors"]'
+            f'nwr["healthcare:speciality"~"{regex}",i]'
             f"(around:{radius_m},{params.lat},{params.lon});"
-            ");"
-            "out center tags;"
         )
+        if is_all(spec) or "doctor" in spec.osm_values:
+            q += (
+                f'nwr["amenity"="doctors"]'
+                f"(around:{radius_m},{params.lat},{params.lon});"
+            )
+        q += ");out center tags;"
+        return q
 
     def _element_to_therapist(self, element: dict[str, Any]) -> TherapistData | None:
         tags = cast(dict[str, str], element.get("tags") or {})
@@ -110,15 +114,6 @@ class OverpassSource(TherapistSource):
             lon=lon,
             sources=[self.name],
         )
-
-
-def _keywords_for(specialty: str) -> tuple[str, ...]:
-    key = (specialty or "").strip().lower()
-    for label, keywords in _SPECIALTY_KEYWORDS.items():
-        if label in key:
-            return keywords
-    # Default: cover therapists and doctors both
-    return ("psychotherapist", "doctor", "psychiatrist")
 
 
 def _element_coords(element: dict[str, Any]) -> tuple[float | None, float | None]:

--- a/therapist_finder/sources/psych_info.py
+++ b/therapist_finder/sources/psych_info.py
@@ -33,6 +33,7 @@ from therapist_finder.sources._html_scraper import (
     text_of,
 )
 from therapist_finder.sources.base import SearchParams
+from therapist_finder.sources.specialties import resolve
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +66,9 @@ class PsychInfoSource(HTMLScraper):
         # psych-info search takes an ``ort`` (city/PLZ) query parameter; the
         # exact path isn't publicly documented, so we keep it configurable.
         pages = max(1, (params.limit_per_source + 19) // 20)
+        verfahren = resolve(params.specialty).verfahren
         return [
-            f"{self.base_url}/suche?ort=Berlin&verfahren={_verfahren(params.specialty)}&seite={i + 1}"
+            f"{self.base_url}/suche?ort=Berlin&verfahren={verfahren}&seite={i + 1}"
             for i in range(pages)
         ]
 
@@ -135,10 +137,3 @@ def _extract_insurance(soup: BeautifulSoup) -> InsuranceType | None:
     return None
 
 
-def _verfahren(specialty: str) -> str:
-    key = specialty.strip().lower()
-    if "kinder" in key:
-        return "KJP"
-    if "psycholog" in key or "psychotherap" in key:
-        return "PP"
-    return ""

--- a/therapist_finder/sources/specialties.py
+++ b/therapist_finder/sources/specialties.py
@@ -1,0 +1,251 @@
+"""Registry of normalized doctor specialties.
+
+The upstream directories each describe specialties in their own dialect
+(OSM ``healthcare:speciality`` values, psych-info ``verfahren`` codes, the
+116117 German "Fachgebiet" labels, and free-text in scraped HTML). This
+module is the single place that maps those dialects onto a small set of
+stable keys the UI can offer as a dropdown.
+
+For each specialty we store:
+
+* ``key``:            stable slug used by the API / frontend.
+* ``label``:          German display label for the dropdown.
+* ``osm_values``:     regex alternatives for the OSM ``healthcare`` /
+                      ``healthcare:speciality`` tag. Also used to decide
+                      which OSM ``amenity=doctors`` hits are relevant.
+* ``de_label``:       the German chamber label for 116117 requests.
+* ``verfahren``:      psych-info ``verfahren`` query parameter value.
+* ``match_patterns``: regex patterns applied to a therapist's name /
+                      therapieform to post-filter results that an upstream
+                      source returned unfiltered (e.g. OSM's generic
+                      ``amenity=doctors``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+from therapist_finder.models import TherapistData
+
+_ALL_KEY = "all"
+
+
+@dataclass(frozen=True)
+class Specialty:
+    """A normalized doctor kind offered in the search UI."""
+
+    key: str
+    label: str
+    osm_values: tuple[str, ...]
+    de_label: str
+    verfahren: str = ""
+    match_patterns: tuple[str, ...] = ()
+
+
+# Ordered: the frontend displays them in this order.
+_SPECIALTIES: tuple[Specialty, ...] = (
+    Specialty(
+        key=_ALL_KEY,
+        label="Alle Ärzte & Therapeut:innen",
+        osm_values=("psychotherapist", "doctor", "psychiatrist"),
+        de_label="Arzt",
+        match_patterns=(),
+    ),
+    Specialty(
+        key="psychotherapie",
+        label="Psychotherapie",
+        osm_values=("psychotherapist", "psychotherapy"),
+        de_label="Psychotherapeut",
+        verfahren="PP",
+        match_patterns=(
+            r"psychotherap",
+            r"verhaltensther",
+            r"tiefenpsycholog",
+            r"\bpp\b",
+        ),
+    ),
+    Specialty(
+        key="kinder_jugend_psychotherapie",
+        label="Kinder- & Jugendpsychotherapie",
+        osm_values=("psychotherapist",),
+        de_label="Kinder- und Jugendlichenpsychotherapeut",
+        verfahren="KJP",
+        match_patterns=(
+            r"kinder[- ]?(und[- ]?)?jugend.*psychotherap",
+            r"kinder.*jugend.*therap",
+            r"\bkjp\b",
+        ),
+    ),
+    Specialty(
+        key="psychiatrie",
+        label="Psychiatrie",
+        osm_values=("psychiatrist", "psychiatry"),
+        de_label="Psychiater",
+        match_patterns=(r"psychiat", r"nervenarzt", r"nervenheil"),
+    ),
+    Specialty(
+        key="kinderarzt",
+        label="Kinder- & Jugendmedizin",
+        osm_values=("pediatrics", "paediatrics"),
+        de_label="Kinder- und Jugendmediziner",
+        match_patterns=(
+            r"kinder[- ]?(und[- ]?)?jugendmedizin",
+            r"kinderarzt",
+            r"kinderheilkunde",
+            r"p(ä|ae)diatr",
+            r"familienmedizin",
+        ),
+    ),
+    Specialty(
+        key="allgemeinmedizin",
+        label="Allgemeinmedizin / Hausarzt",
+        osm_values=("general", "general_practitioner", "doctor"),
+        de_label="Allgemeinmediziner",
+        match_patterns=(
+            r"allgemeinmedizin",
+            r"hausarzt",
+            r"praktischer\s+arzt",
+        ),
+    ),
+    Specialty(
+        key="hno",
+        label="HNO (Hals-Nasen-Ohren)",
+        osm_values=("otolaryngology", "ear_nose_throat"),
+        de_label="HNO-Arzt",
+        match_patterns=(r"\bhno\b", r"hals.nasen", r"otolaryng"),
+    ),
+    Specialty(
+        key="gynaekologie",
+        label="Gynäkologie",
+        osm_values=("gynaecology", "gynecology", "obstetrics"),
+        de_label="Frauenarzt",
+        match_patterns=(r"gyn(ä|ae)kolog", r"frauenheil", r"geburtshilfe"),
+    ),
+    Specialty(
+        key="dermatologie",
+        label="Dermatologie (Haut)",
+        osm_values=("dermatology",),
+        de_label="Dermatologe",
+        match_patterns=(r"dermatolog", r"hautarzt", r"hautheilkunde"),
+    ),
+    Specialty(
+        key="augenarzt",
+        label="Augenheilkunde",
+        osm_values=("ophthalmology",),
+        de_label="Augenarzt",
+        match_patterns=(r"ophthalmolog", r"augenarzt", r"augenheil"),
+    ),
+    Specialty(
+        key="orthopaedie",
+        label="Orthopädie",
+        osm_values=("orthopaedics", "orthopedics"),
+        de_label="Orthopäde",
+        match_patterns=(r"orthop(ä|ae)d",),
+    ),
+    Specialty(
+        key="zahnarzt",
+        label="Zahnarzt",
+        osm_values=("dentist",),
+        de_label="Zahnarzt",
+        match_patterns=(r"zahnarzt", r"zahnheilkunde", r"\bdental\b"),
+    ),
+    Specialty(
+        key="heilpraktiker",
+        label="Heilpraktiker:in (Psychotherapie)",
+        osm_values=("alternative", "psychotherapist"),
+        de_label="Heilpraktiker",
+        match_patterns=(r"heilpraktiker",),
+    ),
+)
+
+SPECIALTIES: dict[str, Specialty] = {s.key: s for s in _SPECIALTIES}
+DEFAULT_KEY = "psychotherapie"
+
+
+def all_specialties() -> tuple[Specialty, ...]:
+    """Return the registered specialties in display order."""
+    return _SPECIALTIES
+
+
+def resolve(key_or_label: str | None) -> Specialty:
+    """Resolve ``key_or_label`` (slug or legacy German label) to a Specialty.
+
+    Falls back to the default specialty when the input is empty or unknown.
+    Accepts legacy German labels like ``"Psychotherapeut"`` so existing
+    clients keep working.
+    """
+    if not key_or_label:
+        return SPECIALTIES[DEFAULT_KEY]
+    raw = key_or_label.strip()
+    lowered = raw.lower()
+    if lowered in SPECIALTIES:
+        return SPECIALTIES[lowered]
+    for spec in _SPECIALTIES:
+        if spec.de_label.lower() == lowered:
+            return spec
+        if spec.label.lower() == lowered:
+            return spec
+    # Heuristic: substring match against German label / key.
+    for spec in _SPECIALTIES:
+        if lowered in spec.de_label.lower() or lowered in spec.key:
+            return spec
+    return SPECIALTIES[DEFAULT_KEY]
+
+
+def is_all(spec: Specialty) -> bool:
+    """Whether ``spec`` is the catch-all option (no filtering)."""
+    return spec.key == _ALL_KEY
+
+
+def _haystack(therapist: TherapistData) -> str:
+    parts: list[str] = [therapist.name or ""]
+    parts.extend(therapist.therapieform or [])
+    if therapist.salutation:
+        parts.append(therapist.salutation)
+    return " ".join(parts).lower()
+
+
+def matches(spec: Specialty, therapist: TherapistData) -> bool:
+    """Return True if ``therapist`` looks like ``spec``.
+
+    The catch-all specialty always matches. Otherwise we look for any of
+    the specialty's ``match_patterns`` in the therapist's name +
+    therapieform + salutation. Entries that don't obviously belong to any
+    specialty fall through as non-matches for every specific filter, which
+    is the right default — users who want "everything" pick ``all``.
+    """
+    if is_all(spec):
+        return True
+    if not spec.match_patterns:
+        return True
+    text = _haystack(therapist)
+    if not text.strip():
+        return False
+    return any(re.search(pat, text) for pat in spec.match_patterns)
+
+
+def infer_key(therapist: TherapistData) -> str | None:
+    """Infer the specialty key for a therapist from its text fields.
+
+    Returns the first specialty whose ``match_patterns`` hit, or ``None``
+    if nothing matched. Used to tag normalised results in API responses.
+    """
+    text = _haystack(therapist)
+    if not text.strip():
+        return None
+    for spec in _SPECIALTIES:
+        if is_all(spec):
+            continue
+        if any(re.search(pat, text) for pat in spec.match_patterns):
+            return spec.key
+    return None
+
+
+def filter_results(
+    spec: Specialty, therapists: list[TherapistData]
+) -> list[TherapistData]:
+    """Drop entries that don't look like ``spec``. No-op for the catch-all."""
+    if is_all(spec):
+        return therapists
+    return [t for t in therapists if matches(spec, t)]


### PR DESCRIPTION
Introduce a normalized specialty registry (specialties.py) that maps a
handful of stable slugs (psychotherapie, psychiatrie, hno, kinderarzt,
allgemeinmedizin, ...) onto each source's dialect: OSM healthcare tag
regexes, psych-info verfahren codes, the 116117 "Fachgebiet" label, and
post-filter match patterns. The crawl now passes the picked slug through
to every source and post-filters merged results so e.g. a
"Psychotherapie" search no longer returns HNO/Kinderarzt mixed in.

TherapistData gains a ``specialty`` field populated by inference from
name + therapieform; the API response exposes both the slug and a German
label so the frontend can show it in the results table. A new
``GET /api/therapists/specialties`` endpoint feeds the dropdown.

Frontend: adds a "Doctor kind" <select> to the search form (with a
static fallback list baked in), plumbs the selection into the API call,
and renders a Specialty column in the results table.

https://claude.ai/code/session_01RMfu69QB2yneS3vDss3t2W