### PR TITLE
chore: ignore GitNexus/Claude artifacts and add agent guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,7 @@ pdf_therapist_parser.py
 therapist_processor.py
 install.sh
 requirements.txt
+
+# GitNexus & Claude Code local artifacts
+.gitnexus/
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **therapist-finder** (1267 symbols, 2176 relationships, 64 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/therapist-finder/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/therapist-finder/clusters` | All functional areas |
+| `gitnexus://repo/therapist-finder/processes` | All execution flows |
+| `gitnexus://repo/therapist-finder/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **therapist-finder** (1267 symbols, 2176 relationships, 64 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/therapist-finder/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/therapist-finder/clusters` | All functional areas |
+| `gitnexus://repo/therapist-finder/processes` | All execution flows |
+| `gitnexus://repo/therapist-finder/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/therapist_finder/api/routes/therapists.py
+++ b/therapist_finder/api/routes/therapists.py
@@ -54,7 +54,9 @@ def _build_source(name: str, settings: Settings) -> object | None:
 
 def _therapist_to_response(t: TherapistData) -> TherapistResponse:
     key = t.specialty or specialties.infer_key(t)
-    label = specialties.SPECIALTIES[key].label if key in specialties.SPECIALTIES else None
+    label = (
+        specialties.SPECIALTIES[key].label if key in specialties.SPECIALTIES else None
+    )
     return TherapistResponse(
         name=t.name,
         address=t.address,
@@ -144,7 +146,11 @@ async def search_by_address(
         origin.lon,
         # Over-fetch so the post-filter has room to drop non-matching hits
         # without starving the response.
-        request.max_results * 4 if not specialties.is_all(spec) else request.max_results,
+        (
+            request.max_results * 4
+            if not specialties.is_all(spec)
+            else request.max_results
+        ),
         geocoder=geocoder,
     )
     geocoder.close()

--- a/therapist_finder/sources/psych_info.py
+++ b/therapist_finder/sources/psych_info.py
@@ -135,5 +135,3 @@ def _extract_insurance(soup: BeautifulSoup) -> InsuranceType | None:
     if has_privat:
         return "privat"
     return None
-
-


### PR DESCRIPTION
## Summary

- Add \`.gitnexus/\` and \`.claude/\` to \`.gitignore\` so local GitNexus indices and Claude Code skills caches stay out of version control.
- Add \`AGENTS.md\` and \`CLAUDE.md\` — GitNexus-generated guides that brief any agent on the codebase (1,267 symbols, 64 execution flows) and the safe-edit workflow.

No functional code changes.

## Test plan

- [ ] CI green
- [ ] \`git status\` after a fresh \`gitnexus analyze\` shows nothing untracked from \`.gitnexus/\` or \`.claude/\`