### PR TITLE
feat(frontend): add Psych-Info link and how-to instructions to step 1

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -820,6 +820,65 @@ html[dir="rtl"] .stepper-list {
 }
 
 /* ========================================
+   Instructions <details> (e.g. how-to-get-PDF-URL)
+   ======================================== */
+
+.instructions-details {
+    margin-bottom: var(--space-lg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg-subtle, var(--color-bg-white));
+}
+
+.instructions-details > summary {
+    list-style: none;
+    cursor: pointer;
+    padding: var(--space-sm) var(--space-md);
+    font-weight: 500;
+    color: var(--color-text);
+    user-select: none;
+}
+
+.instructions-details > summary::-webkit-details-marker {
+    display: none;
+}
+
+.instructions-details > summary::before {
+    content: "▸ ";
+    color: var(--color-text-muted);
+    display: inline-block;
+    transition: transform var(--transition-fast);
+}
+
+.instructions-details[open] > summary::before {
+    transform: rotate(90deg);
+}
+
+.instructions-details[open] > summary {
+    border-bottom: 1px solid var(--color-border);
+}
+
+.instructions-list {
+    margin: 0;
+    padding: var(--space-md) var(--space-lg) var(--space-md) calc(var(--space-lg) + var(--space-md));
+    color: var(--color-text);
+    font-size: var(--font-size-sm);
+    line-height: 1.6;
+}
+
+.instructions-list li + li {
+    margin-top: var(--space-xs);
+}
+
+.instructions-list code {
+    word-break: break-all;
+    font-size: 0.85em;
+    padding: 0.1em 0.3em;
+    background: var(--color-bg-muted, rgba(0, 0, 0, 0.05));
+    border-radius: var(--radius-sm);
+}
+
+/* ========================================
    Overview <details>
    ======================================== */
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -56,6 +56,16 @@
                 </div>
                 <div class="card-body">
                     <div id="search-section">
+                        <details class="instructions-details" id="psych-info-help">
+                            <summary data-i18n="step1.howToTitle">How to get the PDF URL from Psych-Info</summary>
+                            <ol class="instructions-list">
+                                <li data-i18n-html="step1.howStep1">Open <a href="https://psych-info.de/" target="_blank" rel="noopener noreferrer">psych-info.de</a></li>
+                                <li data-i18n="step1.howStep2">Search for therapists at your preferred location</li>
+                                <li data-i18n-html="step1.howStep3">Generate the PDF (button <strong>&ldquo;Liste erstellen f&uuml;r Ausdruck&rdquo;</strong>)</li>
+                                <li data-i18n-html="step1.howStep4">Copy the URL of the opened PDF (e.g. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)</li>
+                                <li data-i18n="step1.howStep5">Paste the URL into the field below</li>
+                            </ol>
+                        </details>
                         <form id="search-form" class="form">
                             <div class="form-group">
                                 <label for="search-pdf-url" data-i18n="step1.urlLabel">Psych-Info PDF URL *</label>

--- a/frontend/js/i18n/ar.json
+++ b/frontend/js/i18n/ar.json
@@ -21,6 +21,12 @@
   "common.continue": "← متابعة",
 
   "step1.heading": "تحميل المعالجين من ملف PDF",
+  "step1.howToTitle": "كيف تحصل على رابط الـ PDF من Psych-Info",
+  "step1.howStep1": "افتح <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "ابحث عن معالجين في الموقع الذي تفضّله",
+  "step1.howStep3": "أنشئ ملف الـ PDF (الزر <strong>«Liste erstellen für Ausdruck»</strong>)",
+  "step1.howStep4": "انسخ رابط ملف الـ PDF المفتوح (مثال: <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "الصق الرابط في الحقل أدناه",
   "step1.urlLabel": "رابط PDF لـ Psych-Info *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "الصق رابط ملف \"Resultate\" من Psych-Info. سنقوم بتحميله وتحليله على الخادم، ثم نعرض القائمة المرتبة بالمعالجين في الخطوة التالية.",

--- a/frontend/js/i18n/de.json
+++ b/frontend/js/i18n/de.json
@@ -21,6 +21,12 @@
   "common.continue": "Weiter →",
 
   "step1.heading": "Therapeut:innen aus einer PDF laden",
+  "step1.howToTitle": "So bekommen Sie die PDF-URL von Psych-Info",
+  "step1.howStep1": "Öffnen Sie <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Suchen Sie nach Therapeut:innen an Ihrem Wunschort",
+  "step1.howStep3": "Erstellen Sie die PDF (Schaltfläche <strong>„Liste erstellen für Ausdruck“</strong>)",
+  "step1.howStep4": "Kopieren Sie die URL der geöffneten PDF (z. B. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Fügen Sie die URL unten in das Feld ein",
   "step1.urlLabel": "Psych-Info-PDF-URL *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Fügen Sie den Link zu einer Psych-Info-„Resultate“-PDF ein. Die Datei wird serverseitig geladen und ausgewertet; im nächsten Schritt erscheint die sortierte Liste der Therapeut:innen.",

--- a/frontend/js/i18n/en.json
+++ b/frontend/js/i18n/en.json
@@ -21,6 +21,12 @@
   "common.continue": "Continue →",
 
   "step1.heading": "Load therapists from a PDF",
+  "step1.howToTitle": "How to get the PDF URL from Psych-Info",
+  "step1.howStep1": "Open <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Search for therapists at your preferred location",
+  "step1.howStep3": "Generate the PDF (button <strong>“Liste erstellen für Ausdruck”</strong>)",
+  "step1.howStep4": "Copy the URL of the opened PDF (e.g. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Paste the URL into the field below",
   "step1.urlLabel": "Psych-Info PDF URL *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Paste the link to a Psych-Info \"Resultate\" PDF. We'll fetch and parse it on the server, then show the ranked list of therapists in the next step.",

--- a/frontend/js/i18n/es.json
+++ b/frontend/js/i18n/es.json
@@ -21,6 +21,12 @@
   "common.continue": "Continuar →",
 
   "step1.heading": "Cargar terapeutas desde un PDF",
+  "step1.howToTitle": "Cómo obtener la URL del PDF de Psych-Info",
+  "step1.howStep1": "Abra <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Busque terapeutas en la ubicación que prefiera",
+  "step1.howStep3": "Genere el PDF (botón <strong>«Liste erstellen für Ausdruck»</strong>)",
+  "step1.howStep4": "Copie la URL del PDF abierto (p. ej. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Pegue la URL en el campo de abajo",
   "step1.urlLabel": "URL del PDF de Psych-Info *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Pegue el enlace a un PDF «Resultate» de Psych-Info. Lo descargamos y analizamos en el servidor y, en el siguiente paso, mostramos la lista ordenada de terapeutas.",

--- a/frontend/js/i18n/fr.json
+++ b/frontend/js/i18n/fr.json
@@ -21,6 +21,12 @@
   "common.continue": "Continuer →",
 
   "step1.heading": "Charger les thérapeutes depuis un PDF",
+  "step1.howToTitle": "Comment obtenir l’URL du PDF depuis Psych-Info",
+  "step1.howStep1": "Ouvrez <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Recherchez des thérapeutes à l’endroit souhaité",
+  "step1.howStep3": "Générez le PDF (bouton <strong>« Liste erstellen für Ausdruck »</strong>)",
+  "step1.howStep4": "Copiez l’URL du PDF ouvert (p. ex. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Collez l’URL dans le champ ci-dessous",
   "step1.urlLabel": "URL du PDF Psych-Info *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Collez le lien vers un PDF « Resultate » de Psych-Info. Nous le récupérons et l'analysons côté serveur, puis affichons la liste classée des thérapeutes à l'étape suivante.",

--- a/frontend/js/i18n/it.json
+++ b/frontend/js/i18n/it.json
@@ -21,6 +21,12 @@
   "common.continue": "Continua →",
 
   "step1.heading": "Carica i terapeuti da un PDF",
+  "step1.howToTitle": "Come ottenere l’URL del PDF da Psych-Info",
+  "step1.howStep1": "Apri <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Cerca terapeuti nella località che preferisci",
+  "step1.howStep3": "Genera il PDF (pulsante <strong>«Liste erstellen für Ausdruck»</strong>)",
+  "step1.howStep4": "Copia l’URL del PDF aperto (es. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Incolla l’URL nel campo qui sotto",
   "step1.urlLabel": "URL del PDF di Psych-Info *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Incolla il link a un PDF «Resultate» di Psych-Info. Lo scarichiamo e lo analizziamo sul server, poi mostriamo l'elenco ordinato dei terapeuti nel passaggio successivo.",

--- a/frontend/js/i18n/ru.json
+++ b/frontend/js/i18n/ru.json
@@ -21,6 +21,12 @@
   "common.continue": "Далее →",
 
   "step1.heading": "Загрузить терапевтов из PDF",
+  "step1.howToTitle": "Как получить URL PDF на Psych-Info",
+  "step1.howStep1": "Откройте <a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a>",
+  "step1.howStep2": "Найдите терапевтов в нужном вам месте",
+  "step1.howStep3": "Сформируйте PDF (кнопка <strong>«Liste erstellen für Ausdruck»</strong>)",
+  "step1.howStep4": "Скопируйте URL открывшегося PDF (например, <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "Вставьте URL в поле ниже",
   "step1.urlLabel": "URL PDF Psych-Info *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Вставьте ссылку на PDF «Resultate» сайта Psych-Info. Мы скачаем и обработаем его на сервере, а на следующем шаге покажем отсортированный список терапевтов.",

--- a/frontend/js/i18n/tr.json
+++ b/frontend/js/i18n/tr.json
@@ -21,6 +21,12 @@
   "common.continue": "Devam et →",
 
   "step1.heading": "PDF'den terapistleri yükle",
+  "step1.howToTitle": "Psych-Info'dan PDF URL'sini nasıl alırsınız",
+  "step1.howStep1": "<a href=\"https://psych-info.de/\" target=\"_blank\" rel=\"noopener noreferrer\">psych-info.de</a> adresini açın",
+  "step1.howStep2": "Tercih ettiğiniz konumda terapist arayın",
+  "step1.howStep3": "PDF'yi oluşturun (<strong>“Liste erstellen für Ausdruck”</strong> düğmesi)",
+  "step1.howStep4": "Açılan PDF'nin URL'sini kopyalayın (ör. <code>https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_6a0ax0x0x0x0.pdf</code>)",
+  "step1.howStep5": "URL'yi aşağıdaki alana yapıştırın",
   "step1.urlLabel": "Psych-Info PDF URL'si *",
   "step1.urlPlaceholder": "https://psych-info.de/wp-content/uploads/pdf/psych-info_resultate_…pdf",
   "step1.urlHint": "Psych-Info \"Resultate\" PDF bağlantısını yapıştırın. Bağlantıyı sunucuda indirip ayrıştırırız ve bir sonraki adımda sıralı terapist listesini gösteririz.",


### PR DESCRIPTION
Closes #24.

## Summary
- Adds a collapsed `<details>` block above the URL form on step 1 with a 5-step instruction on how to obtain a Psych-Info PDF URL, including an outbound link to https://psych-info.de/.
- New styling for `.instructions-details` / `.instructions-list` (matches the existing overview-details look, smaller spacing).
- Translated the 6 new i18n keys (`step1.howToTitle`, `step1.howStep1`–`step1.howStep5`) into all 8 supported UI languages (de, en, fr, ar, tr, es, it, ru).

## Test plan
- [ ] Open the app, step 1: the "How to get the PDF URL from Psych-Info" expander is visible above the URL field and starts collapsed.
- [ ] Expanding it shows 5 ordered steps, with `psych-info.de` rendered as a clickable link that opens in a new tab.
- [ ] Switch UI language (de/fr/ar/tr/es/it/ru/en) — all 5 steps and the summary are translated.
- [ ] Long PDF URL example wraps cleanly on mobile widths.