### PR TITLE
feat: persist contacted therapists in SQLite + balance send queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ __pycache__/
 frontend/node_modules/
 frontend/dist/
 
+# Runtime SQLite database for /api/contacts
+contacts.db
+*.db-journal
+
 # Distribution / packaging
 .Python
 build/

--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ output_directory: "clients"
 default_subject: "Terminanfrage"
 ```
 
+### Contacts database
+
+The `/api/contacts/*` endpoints (used for the send-queue balancer and
+"don't email the same therapist twice" dedupe) persist to a SQLite file.
+Path is configurable via `THERAPIST_FINDER_CONTACTS_DB`; default is
+`contacts.db` in the working directory.
+
+> ⚠️ **Render free tier:** the service runs on ephemeral disk, so
+> `contacts.db` is wiped on every redeploy and after long idle periods.
+> Counts and per-browser history reset with it. For durable storage,
+> attach a Render persistent disk and point `THERAPIST_FINDER_CONTACTS_DB`
+> at a path on it, or migrate the store to managed Postgres
+> (`therapist_finder/api/contacts_store.py` is the only module that needs
+> to change).
+
 ## Development
 
 ### Setup Development Environment

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -161,3 +161,40 @@ export function downloadFile(content, filename, mimeType = 'text/plain') {
 export async function healthCheck() {
     return request('/health');
 }
+
+/**
+ * Record that this browser opened a mail draft for the given therapist.
+ * @param {string} email
+ * @param {string} browserId
+ * @returns {Promise<{recorded: boolean}>}
+ */
+export async function recordContact(email, browserId) {
+    return request('/contacts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, browser_id: browserId }),
+    });
+}
+
+/**
+ * Fetch global contact counts for a list of therapist emails.
+ * @param {string[]} emails
+ * @returns {Promise<{counts: Record<string, number>}>}
+ */
+export async function getContactCounts(emails) {
+    return request('/contacts/counts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ emails }),
+    });
+}
+
+/**
+ * Fetch the emails this browser has already contacted.
+ * @param {string} browserId
+ * @returns {Promise<{emails: string[]}>}
+ */
+export async function getMyContacts(browserId) {
+    const qs = new URLSearchParams({ browser_id: browserId });
+    return request(`/contacts/mine?${qs}`);
+}

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -7,9 +7,12 @@ import {
     APIError,
     downloadFile,
     generateEmails,
+    getContactCounts,
+    getMyContacts,
     getTemplate,
     parseFile,
     parseUrl,
+    recordContact,
 } from './api.js';
 import {
     SUPPORTED_LANGS,
@@ -26,7 +29,29 @@ import {
 
 const STATE_STORAGE_KEY = 'therapist-finder:state';
 const CONTACTED_STORAGE_KEY = 'therapist-finder:contacted-emails';
+const BROWSER_ID_STORAGE_KEY = 'therapist-finder:browser-id';
 const MAILTO_MAX_LENGTH = 1900;
+
+/**
+ * Return a stable anonymous identifier for this browser, generating one
+ * on first use. Used by the backend to attribute contact events without
+ * any login flow.
+ */
+function getBrowserId() {
+    try {
+        let id = localStorage.getItem(BROWSER_ID_STORAGE_KEY);
+        if (!id) {
+            id =
+                typeof crypto !== 'undefined' && crypto.randomUUID
+                    ? crypto.randomUUID()
+                    : `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+            localStorage.setItem(BROWSER_ID_STORAGE_KEY, id);
+        }
+        return id;
+    } catch {
+        return `anon-${Date.now()}`;
+    }
+}
 const TRUNCATION_MARKER = '\n\n[… truncated — use "Copy body" to paste full text]';
 
 const STEPS = ['url', 'overview', 'me', 'template', 'send'];
@@ -632,7 +657,47 @@ function currentQueueDraft() {
     return items[index] || null;
 }
 
-function initSendView() {
+/**
+ * Build the send queue, prioritising therapists with the fewest global
+ * contact records (the "balancer") and filtering out emails this browser
+ * has already contacted. Falls back to localStorage-only behaviour if the
+ * backend is unreachable so the flow still works offline.
+ */
+async function buildBalancedQueue(drafts) {
+    const draftsWithEmail = drafts.filter((d) => d.to);
+    const emails = draftsWithEmail.map((d) => d.to.toLowerCase());
+    const localContacted = loadContactedEmails();
+
+    let counts = {};
+    let myContacted = new Set(localContacted);
+    try {
+        const browserId = getBrowserId();
+        const [countsRes, mineRes] = await Promise.all([
+            getContactCounts(emails),
+            getMyContacts(browserId),
+        ]);
+        counts = countsRes.counts || {};
+        for (const email of mineRes.emails || []) {
+            myContacted.add(email.toLowerCase());
+        }
+    } catch (error) {
+        console.warn('Falling back to localStorage-only queue:', error);
+    }
+
+    const items = draftsWithEmail
+        .map((draft, originalIndex) => ({
+            draft,
+            originalIndex,
+            count: counts[draft.to.toLowerCase()] ?? 0,
+        }))
+        .filter(({ draft }) => !myContacted.has(draft.to.toLowerCase()))
+        .sort((a, b) => a.count - b.count || a.originalIndex - b.originalIndex)
+        .map(({ draft }) => draft);
+
+    return items;
+}
+
+async function initSendView() {
     const drafts = (state.results && state.results.drafts) || [];
     if (drafts.length === 0) {
         showStatus(elements.queueStatus, t('step5.statusNoDrafts'), 'warning');
@@ -647,8 +712,7 @@ function initSendView() {
         state.queue.index >= state.queue.items.length;
 
     if (needsRebuild) {
-        const contacted = loadContactedEmails();
-        const items = drafts.filter((d) => d.to && !contacted.has(d.to.toLowerCase()));
+        const items = await buildBalancedQueue(drafts);
         state.queue = { items, index: 0 };
         persistState();
     }
@@ -710,6 +774,11 @@ function handleQueueOpen() {
     document.body.removeChild(link);
 
     markEmailContacted(draft.to);
+    // Best-effort backend persistence; the localStorage write above keeps
+    // the user-visible behaviour working even if the API is unreachable.
+    recordContact(draft.to, getBrowserId()).catch((error) => {
+        console.warn('Failed to record contact on backend:', error);
+    });
     elements.queueNext.disabled = false;
     elements.queueOpen.disabled = true;
     showStatus(elements.queueStatus, t('step5.statusMailOpened'), 'info');

--- a/tests/test_api_contacts.py
+++ b/tests/test_api_contacts.py
@@ -1,0 +1,93 @@
+"""Tests for /api/contacts/* endpoints and the SQLite contacts store."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+import pytest
+
+from therapist_finder.api import contacts_store
+from therapist_finder.api.main import app
+
+
+@pytest.fixture
+def temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Point the contacts store at a fresh SQLite file per test."""
+    db = tmp_path / "contacts.db"
+    monkeypatch.setenv("THERAPIST_FINDER_CONTACTS_DB", str(db))
+    contacts_store.init_db()
+    yield db
+
+
+def test_record_contact_is_idempotent(temp_db: Path) -> None:
+    client = TestClient(app)
+    payload = {"email": "Foo@Example.com", "browser_id": "anon-1"}
+
+    first = client.post("/api/contacts", json=payload)
+    assert first.status_code == 200, first.text
+    assert first.json() == {"recorded": True}
+
+    second = client.post("/api/contacts", json=payload)
+    assert second.status_code == 200
+    assert second.json() == {"recorded": False}
+
+
+def test_counts_aggregates_across_browsers(temp_db: Path) -> None:
+    client = TestClient(app)
+    client.post("/api/contacts", json={"email": "a@example.com", "browser_id": "b1"})
+    client.post("/api/contacts", json={"email": "a@example.com", "browser_id": "b2"})
+    client.post("/api/contacts", json={"email": "b@example.com", "browser_id": "b1"})
+
+    resp = client.post(
+        "/api/contacts/counts",
+        json={"emails": ["a@example.com", "b@example.com", "c@example.com"]},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "counts": {
+            "a@example.com": 2,
+            "b@example.com": 1,
+            "c@example.com": 0,
+        }
+    }
+
+
+def test_counts_is_case_insensitive(temp_db: Path) -> None:
+    client = TestClient(app)
+    client.post(
+        "/api/contacts",
+        json={"email": "MixedCase@example.com", "browser_id": "b1"},
+    )
+    resp = client.post(
+        "/api/contacts/counts", json={"emails": ["mixedcase@EXAMPLE.com"]}
+    )
+    assert resp.json()["counts"]["mixedcase@example.com"] == 1
+
+
+def test_mine_returns_only_this_browser(temp_db: Path) -> None:
+    client = TestClient(app)
+    client.post("/api/contacts", json={"email": "a@example.com", "browser_id": "alice"})
+    client.post("/api/contacts", json={"email": "b@example.com", "browser_id": "alice"})
+    client.post("/api/contacts", json={"email": "c@example.com", "browser_id": "bob"})
+
+    alice = client.get("/api/contacts/mine", params={"browser_id": "alice"})
+    assert alice.status_code == 200
+    assert alice.json() == {"emails": ["a@example.com", "b@example.com"]}
+
+    bob = client.get("/api/contacts/mine", params={"browser_id": "bob"})
+    assert bob.json() == {"emails": ["c@example.com"]}
+
+
+def test_mine_requires_browser_id(temp_db: Path) -> None:
+    client = TestClient(app)
+    resp = client.get("/api/contacts/mine")
+    assert resp.status_code == 422
+
+
+def test_record_rejects_empty_fields(temp_db: Path) -> None:
+    client = TestClient(app)
+    resp = client.post("/api/contacts", json={"email": "  ", "browser_id": "anon"})
+    # ValueError is mapped to 400 by the global exception handler.
+    assert resp.status_code == 400

--- a/therapist_finder/api/contacts_store.py
+++ b/therapist_finder/api/contacts_store.py
@@ -1,0 +1,133 @@
+"""SQLite-backed log of therapist contact events.
+
+Tracks which therapist emails have been contacted, by which anonymous
+browser id, and when. The schema enforces one record per (email, browser_id)
+so repeated mailto-opens by the same browser are idempotent.
+
+The store powers two features:
+- per-browser dedupe: a user never sees a therapist they personally
+  already contacted.
+- global balancer: the frontend sorts the send queue ascending by global
+  contact count, so therapists nobody has contacted yet appear first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+import sqlite3
+
+_DEFAULT_DB_PATH = Path("contacts.db")
+
+
+def db_path() -> Path:
+    """Resolve the SQLite path from THERAPIST_FINDER_CONTACTS_DB env var."""
+    return Path(os.getenv("THERAPIST_FINDER_CONTACTS_DB", str(_DEFAULT_DB_PATH)))
+
+
+@contextmanager
+def _connect(path: Path | None = None) -> Iterator[sqlite3.Connection]:
+    target = path or db_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(target))
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def init_db(path: Path | None = None) -> None:
+    """Create the contacts table and indexes if they do not exist."""
+    with _connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS contacts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                email TEXT NOT NULL,
+                browser_id TEXT NOT NULL,
+                contacted_at TEXT NOT NULL,
+                UNIQUE(email, browser_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_contacts_email
+                ON contacts(email);
+            CREATE INDEX IF NOT EXISTS idx_contacts_browser
+                ON contacts(browser_id);
+            """
+        )
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+def record_contact(
+    email: str,
+    browser_id: str,
+    *,
+    path: Path | None = None,
+    now: datetime | None = None,
+) -> bool:
+    """Record that ``browser_id`` contacted ``email``.
+
+    Returns True if a new row was inserted, False if the pair already existed.
+    """
+    normalized = _normalize_email(email)
+    if not normalized or not browser_id.strip():
+        raise ValueError("email and browser_id are required")
+    when = (now or datetime.now(timezone.utc)).isoformat()
+    with _connect(path) as conn:
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO contacts (email, browser_id, contacted_at) "
+            "VALUES (?, ?, ?)",
+            (normalized, browser_id.strip(), when),
+        )
+        return bool(cur.rowcount > 0)
+
+
+def get_counts(
+    emails: Iterable[str] | None = None,
+    *,
+    path: Path | None = None,
+) -> dict[str, int]:
+    """Return ``{email: contact_count}`` for the given emails (or all)."""
+    with _connect(path) as conn:
+        if emails is None:
+            rows = conn.execute(
+                "SELECT email, COUNT(*) AS n FROM contacts GROUP BY email"
+            ).fetchall()
+            return {row["email"]: row["n"] for row in rows}
+
+        normalized = [_normalize_email(e) for e in emails if e and e.strip()]
+        if not normalized:
+            return {}
+        # `placeholders` is a fixed string of `?,?,?` derived from the count
+        # only; all email values are bound via parameters below.
+        placeholders = ",".join("?" * len(normalized))
+        query = (
+            "SELECT email, COUNT(*) AS n FROM contacts "  # nosec B608
+            f"WHERE email IN ({placeholders}) GROUP BY email"
+        )
+        rows = conn.execute(query, normalized).fetchall()
+        counts = {row["email"]: row["n"] for row in rows}
+        # Fill zeros for asked-about emails that have no contacts yet so the
+        # frontend can rely on every requested key being present.
+        for email in normalized:
+            counts.setdefault(email, 0)
+        return counts
+
+
+def get_user_contacts(browser_id: str, *, path: Path | None = None) -> list[str]:
+    """Return emails this browser has already contacted (lowercased)."""
+    if not browser_id.strip():
+        return []
+    with _connect(path) as conn:
+        rows = conn.execute(
+            "SELECT email FROM contacts WHERE browser_id = ? ORDER BY email",
+            (browser_id.strip(),),
+        ).fetchall()
+        return [row["email"] for row in rows]

--- a/therapist_finder/api/main.py
+++ b/therapist_finder/api/main.py
@@ -1,5 +1,7 @@
 """FastAPI application entry point."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 import os
 from pathlib import Path
 
@@ -8,14 +10,28 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from .routes import emails, therapists
+from . import contacts_store
+from .routes import contacts, emails, therapists
 from .schemas import HealthResponse
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Initialise the contacts SQLite schema on app startup.
+
+    Done here (not at import time) so importing the app for tests or tooling
+    doesn't create a stray DB file at the project root.
+    """
+    contacts_store.init_db()
+    yield
+
 
 # Create FastAPI app
 app = FastAPI(
     title="Therapist Finder API",
     description="API for parsing therapist data and generating email drafts",
     version="1.0.0",
+    lifespan=_lifespan,
 )
 
 _default_origins = [
@@ -69,6 +85,7 @@ async def health_check() -> HealthResponse:
 # Register API routes
 app.include_router(therapists.router, prefix="/api")
 app.include_router(emails.router, prefix="/api")
+app.include_router(contacts.router, prefix="/api")
 
 
 # Serve frontend static files

--- a/therapist_finder/api/routes/contacts.py
+++ b/therapist_finder/api/routes/contacts.py
@@ -1,0 +1,63 @@
+"""Contact-log endpoints: record sent emails and query global counts."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from .. import contacts_store
+
+router = APIRouter(prefix="/contacts", tags=["contacts"])
+
+
+class RecordContactRequest(BaseModel):
+    """Payload for POST /api/contacts."""
+
+    email: str = Field(..., description="Therapist email that was contacted")
+    browser_id: str = Field(..., description="Anonymous per-browser identifier")
+
+
+class RecordContactResponse(BaseModel):
+    """Result of POST /api/contacts."""
+
+    recorded: bool = Field(..., description="True if a new row was inserted")
+
+
+class CountsRequest(BaseModel):
+    """Payload for POST /api/contacts/counts."""
+
+    emails: list[str] = Field(
+        default_factory=list,
+        description="Emails to look up; case-insensitive",
+    )
+
+
+class CountsResponse(BaseModel):
+    """Global contact count per email; missing keys default to 0."""
+
+    counts: dict[str, int]
+
+
+class MineResponse(BaseModel):
+    """Emails this browser has already contacted."""
+
+    emails: list[str]
+
+
+@router.post("", response_model=RecordContactResponse)
+async def record(req: RecordContactRequest) -> RecordContactResponse:
+    """Record a contact event. Idempotent per ``(email, browser_id)``."""
+    inserted = contacts_store.record_contact(req.email, req.browser_id)
+    return RecordContactResponse(recorded=inserted)
+
+
+@router.post("/counts", response_model=CountsResponse)
+async def counts(req: CountsRequest) -> CountsResponse:
+    """Return global contact count per email. Missing keys default to 0."""
+    return CountsResponse(counts=contacts_store.get_counts(req.emails))
+
+
+@router.get("/mine", response_model=MineResponse)
+async def mine(browser_id: str = Query(..., min_length=1)) -> MineResponse:
+    """Return emails this browser has already contacted."""
+    return MineResponse(emails=contacts_store.get_user_contacts(browser_id))


### PR DESCRIPTION
Closes #18 and #21.

## Summary
- **Backend:** new SQLite-backed contact log (`therapist_finder/api/contacts_store.py`) with three endpoints under `/api/contacts`: `POST` to record, `POST /counts` for global counts per email, `GET /mine` for this browser's history. DB path is overridable via `THERAPIST_FINDER_CONTACTS_DB`; init happens in a FastAPI lifespan so bare imports don't create stray files.
- **Frontend:** generates a stable anonymous UUID per browser, fetches global counts + own contact history when entering step 5, and rebuilds the queue sorted ascending by global count — therapists nobody has contacted yet appear first (the "balancer"). `mailto`-open records the contact on the backend (fire-and-forget) and still updates localStorage so the flow keeps working if the API is unreachable.
- **Tests:** new `tests/test_api_contacts.py` covers idempotency per `(email, browser_id)`, case-insensitive aggregation, per-browser filter, and validation. 52/52 pass.

## Test plan
- [x] `poetry run pytest` — 52 passed
- [x] `poetry run ruff check` + `ruff format --check`
- [x] `poetry run mypy` on touched modules
- [x] `bandit` + `pydocstyle` via pre-commit
- [x] Smoke test of all three endpoints via `TestClient` with lifespan
- [ ] Manual click-through in browser: load a Psych-Info PDF, complete steps 1–4, verify step 5 orders previously-contacted therapists last and that opening a draft removes them from the queue for next visit.

## Notes
- Render free tier has ephemeral disk: `contacts.db` is wiped on redeploy. If long-term persistence becomes important, mount a Render disk (or move to managed Postgres) — the store is the only thing that needs to point elsewhere.