### PR TITLE
docs: document GEMINI_MODEL override + refresh gitnexus stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **therapist-finder** (1267 symbols, 2176 relationships, 64 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **therapist-finder** (1690 symbols, 3076 relationships, 131 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **therapist-finder** (1267 symbols, 2176 relationships, 64 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **therapist-finder** (1690 symbols, 3076 relationships, 131 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ the endpoint returns 503 and the frontend shows an inline "not configured"
 notice — everything else still works, the user just writes the body
 themselves.
 
+| Env var | Default | Purpose |
+|---|---|---|
+| `GEMINI_API_KEY` | _unset_ | Enables the feature when set. |
+| `GEMINI_MODEL`   | `gemini-2.5-flash-lite` | Override the model without redeploying. Useful when Google rotates free-tier quotas (e.g. `gemini-2.5-flash`, `gemini-flash-latest`). Check your account's quota at <https://ai.dev/rate-limit>. |
+
 No PII is sent to the LLM: only the target language, insurance label,
 and previously sent bodies to the same therapists (for anti-repetition).
 Greeting, contact info, and closing are inserted client-side after

--- a/render.yaml
+++ b/render.yaml
@@ -20,3 +20,7 @@ services:
       # it the endpoint returns 503 and the frontend shows an inline notice.
       - key: GEMINI_API_KEY
         sync: false
+      # Optional: override the Gemini model id without redeploying.
+      # Defaults to gemini-2.5-flash-lite (current free-tier-friendly).
+      - key: GEMINI_MODEL
+        sync: false


### PR DESCRIPTION
## Summary
- README + render.yaml: document the `GEMINI_MODEL` env var added in #39 so operators can swap models without a redeploy when Google rotates free-tier quotas.
- AGENTS.md / CLAUDE.md: refresh gitnexus stats after the AI mail body feature landed (1267→1690 symbols, 64→131 execution flows).

## Test plan
- [x] No code change; docs-only PR